### PR TITLE
build: pass `config.optimize` to catch2

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -281,7 +281,7 @@ fn addArtifacts(b: *std.Build, config: struct {
         const test_runner = b.path(ProjectPaths.test_runner ++ "main.zig");
         const catch2_dep = catch2.build(b, .{
             .target = target,
-            .optimize = .Debug,
+            .optimize = config.optimize,
         });
 
         // The runner has standalone tests


### PR DESCRIPTION
fixes #30

without this, `zig build --release` will compile catch2 with ubsan, then fail to link ubsan into the final binary