### PR TITLE
[compiler]: Add right associativity for assignments and adjust their

### DIFF
--- a/doc/syntax/arrays.md
+++ b/doc/syntax/arrays.md
@@ -1,7 +1,7 @@
 # Arrays
 ## Declarations
 - Arrays are defined with 3 key components
-    - A size: This must be an underscore (signifying inferred size), a compile time constant (denoted with `comptime`), or a usize integer literal (suffix `uz`)
+    - A size: This must be an underscore (signifying inferred size), a compile time constant (denoted with `constexpr`), or a usize integer literal (suffix `uz`)
     - A type: This can be any valid type, but it must be present and cannot be inferred
     - Items: These items must be of the type specified, and must match the provided size if provided
 - Arrays are immutably sized, though internal elements can be mutable based on the provided type

--- a/doc/syntax/declarations.md
+++ b/doc/syntax/declarations.md
@@ -26,10 +26,10 @@ var e: []byte;         // Allowed, e is forward declared and future assignments 
 - A mutable reference cannot be taken from a constant
 
 ## Compile-time Constants
-- Compile-time-known constants are declared with the `comptime` keyword
-- In most cases, `comptime` values behave identically to `const` constants
-    - The only difference is that `comptime` values can be used as array sizes, assuming their underlying type is `usize`
-- A `comptime` declaration can not be declared `extern`
+- Compile-time-known constants are declared with the `constexpr` keyword
+- In most cases, `constexpr` values behave identically to `const` constants
+    - The only difference is that `constexpr` values can be used as array sizes, assuming their underlying type is `usize`
+- A `constexpr` declaration can not be declared `extern`
 
 ## Variables
 - Variables are declared with the `var keyword
@@ -57,5 +57,15 @@ pub var c := 2;         // Allowed, symbol can be imported
 extern const a: int;    // Allowed, externs must be explicitly typed without values
 export var b := 1;      // Allowed
 static var c := 33;     // Illegal, cannot use static on a non-struct member
-extern comptime a: int; // Illegal, inherently contradictory
+extern constexpr a: int; // Illegal, inherently contradictory
 ```
+
+## Assignment
+- Non-const declarations can be reassigned
+- Re-assignment is right associative, meaning that you can chain assignment expressions:
+```porpoise
+var a: int = 2;
+var b: int = 5;
+a = (b = 6);
+```
+- This works because an assignment returns the assigned value

--- a/packages/compiler/include/ast/expressions/infix.hpp
+++ b/packages/compiler/include/ast/expressions/infix.hpp
@@ -25,10 +25,15 @@ template <typename Derived> class InfixExpression : public ExprBase<Derived> {
 
     [[nodiscard]] static auto parse(syntax::Parser& parser, mem::Box<Expression> lhs)
         -> Expected<mem::Box<Expression>, syntax::ParserDiagnostic> {
-        const auto op_token           = parser.current_token();
-        const auto current_precedence = parser.poll_current_precedence();
+        const auto op_token = parser.current_token();
         if (parser.peek_token_is(syntax::TokenType::END)) {
             return make_parser_unexpected(syntax::ParserError::INFIX_MISSING_RHS, op_token);
+        }
+
+        auto [current_precedence, current_binding] = parser.poll_current_precedence();
+        if (current_binding && current_binding->right_assoc) {
+            current_precedence =
+                static_cast<syntax::Precedence>(std::to_underlying(current_precedence) - 1);
         }
 
         parser.advance();

--- a/packages/compiler/include/ast/statements/declaration.hpp
+++ b/packages/compiler/include/ast/statements/declaration.hpp
@@ -16,13 +16,13 @@ class IdentifierExpression;
 class TypeExpression;
 
 enum class DeclModifiers : u8 {
-    VARIABLE = 1 << 0,
-    CONSTANT = 1 << 1,
-    COMPTIME = 1 << 2,
-    PUBLIC   = 1 << 3,
-    EXTERN   = 1 << 4,
-    EXPORT   = 1 << 5,
-    STATIC   = 1 << 6,
+    VARIABLE  = 1 << 0,
+    CONSTANT  = 1 << 1,
+    CONSTEXPR = 1 << 2,
+    PUBLIC    = 1 << 3,
+    EXTERN    = 1 << 4,
+    EXPORT    = 1 << 5,
+    STATIC    = 1 << 6,
 };
 
 constexpr auto operator|(DeclModifiers lhs, DeclModifiers rhs) -> DeclModifiers {
@@ -82,7 +82,7 @@ class DeclStatement : public StmtBase<DeclStatement> {
     static constexpr auto LEGAL_MODIFIERS = std::to_array<ModifierMapping>({
         {syntax::TokenType::VAR, DeclModifiers::VARIABLE},
         {syntax::TokenType::CONST, DeclModifiers::CONSTANT},
-        {syntax::TokenType::COMPTIME, DeclModifiers::COMPTIME},
+        {syntax::TokenType::CONSTEXPR, DeclModifiers::CONSTEXPR},
         {syntax::TokenType::PUBLIC, DeclModifiers::PUBLIC},
         {syntax::TokenType::EXTERN, DeclModifiers::EXTERN},
         {syntax::TokenType::EXPORT, DeclModifiers::EXPORT},
@@ -93,18 +93,18 @@ class DeclStatement : public StmtBase<DeclStatement> {
         // Exactly one mutability flag must be set
         const auto valid_mut = std::popcount(std::to_underlying(
                                    modifiers & (DeclModifiers::VARIABLE | DeclModifiers::CONSTANT |
-                                                DeclModifiers::COMPTIME))) == 1;
+                                                DeclModifiers::CONSTEXPR))) == 1;
 
         // Comptime values cannot be known at link time, obviously
-        const auto valid_comptime =
+        const auto valid_constexpr =
             std::popcount(std::to_underlying(
-                modifiers & (DeclModifiers::EXTERN | DeclModifiers::COMPTIME))) <= 1;
+                modifiers & (DeclModifiers::EXTERN | DeclModifiers::CONSTEXPR))) <= 1;
 
         // At most one ABI flag can be set
         const auto valid_abi =
             std::popcount(std::to_underlying(modifiers &
                                              (DeclModifiers::EXTERN | DeclModifiers::EXPORT))) <= 1;
-        return valid_mut && valid_comptime && valid_abi;
+        return valid_mut && valid_constexpr && valid_abi;
     }
 
     static constexpr auto token_to_modifier(const syntax::Token& tok) -> Optional<DeclModifiers> {

--- a/packages/compiler/include/syntax/keywords.hpp
+++ b/packages/compiler/include/syntax/keywords.hpp
@@ -18,7 +18,7 @@ namespace keywords {
 constexpr Keyword FN{"fn", TokenType::FUNCTION};
 constexpr Keyword VAR{"var", TokenType::VAR};
 constexpr Keyword CONST{"const", TokenType::CONST};
-constexpr Keyword COMPTIME{"comptime", TokenType::COMPTIME};
+constexpr Keyword CONSTEXPR{"constexpr", TokenType::CONSTEXPR};
 constexpr Keyword STRUCT{"struct", TokenType::STRUCT};
 constexpr Keyword ENUM{"enum", TokenType::ENUM};
 constexpr Keyword UNION{"union", TokenType::UNION};
@@ -97,9 +97,9 @@ constexpr Keyword CTZ{"@ctz", TokenType::CTZ};
 
 } // namespace keywords
 
-constexpr auto ALL_KEYWORDS = []() {
+constexpr auto ALL_KEYWORDS = [] {
     auto all_keywords = std::array{
-        keywords::FN,       keywords::VAR,     keywords::CONST,    keywords::COMPTIME,
+        keywords::FN,       keywords::VAR,     keywords::CONST,    keywords::CONSTEXPR,
         keywords::STRUCT,   keywords::ENUM,    keywords::UNION,    keywords::TRUE,
         keywords::FALSE,    keywords::IF,      keywords::ELSE,     keywords::DO,
         keywords::MATCH,    keywords::RETURN,  keywords::DEFER,    keywords::LOOP,
@@ -137,7 +137,7 @@ constexpr auto ALL_PRIMITIVES = std::array{
     keywords::TYPE.second,
 };
 
-constexpr auto ALL_BUILTINS = []() {
+constexpr auto ALL_BUILTINS = [] {
     using namespace keywords;
     auto all_builtins = std::array{
         builtins::TYPEOF,

--- a/packages/compiler/include/syntax/operators.hpp
+++ b/packages/compiler/include/syntax/operators.hpp
@@ -64,7 +64,7 @@ constexpr Operator NULL_TERMINATED{":0", TokenType::NULL_TERMINATED};
 
 } // namespace operators
 
-constexpr auto ALL_OPERATORS = []() {
+constexpr auto ALL_OPERATORS = [] {
     auto all_operators = std::array{
         operators::ASSIGN,
         operators::WALRUS,

--- a/packages/compiler/include/syntax/parser.hpp
+++ b/packages/compiler/include/syntax/parser.hpp
@@ -145,8 +145,8 @@ class Parser {
         return tt_mismatch_error(expected, peek_token_);
     }
 
-    auto poll_current_precedence() const noexcept -> Precedence;
-    auto poll_peek_precedence() const noexcept -> Precedence;
+    auto poll_current_precedence() const noexcept -> std::pair<Precedence, Optional<Binding>>;
+    auto poll_peek_precedence() const noexcept -> std::pair<Precedence, Optional<Binding>>;
 
     [[nodiscard]] auto parse_statement() -> Expected<mem::Box<ast::Statement>, ParserDiagnostic>;
     [[nodiscard]] auto parse_expression(Precedence precedence = Precedence::LOWEST)

--- a/packages/compiler/include/syntax/precedence.hpp
+++ b/packages/compiler/include/syntax/precedence.hpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <array>
-#include <utility>
 
 #include "syntax/token.hpp"
 
@@ -13,22 +12,26 @@ namespace porpoise::syntax {
 
 enum class Precedence : u8 {
     LOWEST,
-    BOOL_AND_OR,
-    BOOL_EQUIV,
-    BOOL_LT_GT,
-    ADD_SUB,
-    MUL_DIV,
-    EXPONENT,
-    PREFIX,
-    RANGE,
-    ASSIGNMENT,
-    SCOPE_RESOLUTION,
-    GROUP_CALL_IDX,
+    ASSIGNMENT       = 10,
+    BOOL_AND_OR      = 20,
+    BOOL_EQUIV       = 30,
+    BOOL_LT_GT       = 40,
+    ADD_SUB          = 50,
+    MUL_DIV          = 60,
+    EXPONENT         = 70,
+    PREFIX           = 80,
+    RANGE            = 90,
+    SCOPE_RESOLUTION = 100,
+    GROUP_CALL_IDX   = 110,
 };
 
-using Binding = std::pair<TokenType, Precedence>;
+struct Binding {
+    TokenType  type;
+    Precedence precedence;
+    bool       right_assoc{false};
+};
 
-constexpr auto ALL_BINDINGS = []() {
+constexpr auto ALL_BINDINGS = [] {
     auto all_bindings = std::to_array<Binding>({
         {TokenType::PLUS, Precedence::ADD_SUB},
         {TokenType::MINUS, Precedence::ADD_SUB},
@@ -52,29 +55,29 @@ constexpr auto ALL_BINDINGS = []() {
         {TokenType::LBRACKET, Precedence::GROUP_CALL_IDX},
         {TokenType::DOT_DOT, Precedence::RANGE},
         {TokenType::DOT_DOT_EQ, Precedence::RANGE},
-        {TokenType::ASSIGN, Precedence::ASSIGNMENT},
-        {TokenType::PLUS_ASSIGN, Precedence::ASSIGNMENT},
-        {TokenType::MINUS_ASSIGN, Precedence::ASSIGNMENT},
-        {TokenType::STAR_ASSIGN, Precedence::ASSIGNMENT},
-        {TokenType::SLASH_ASSIGN, Precedence::ASSIGNMENT},
-        {TokenType::PERCENT_ASSIGN, Precedence::ASSIGNMENT},
-        {TokenType::BW_AND_ASSIGN, Precedence::ASSIGNMENT},
-        {TokenType::BW_OR_ASSIGN, Precedence::ASSIGNMENT},
-        {TokenType::SHL_ASSIGN, Precedence::ASSIGNMENT},
-        {TokenType::SHR_ASSIGN, Precedence::ASSIGNMENT},
-        {TokenType::NOT_ASSIGN, Precedence::ASSIGNMENT},
-        {TokenType::XOR_ASSIGN, Precedence::ASSIGNMENT},
+        {TokenType::ASSIGN, Precedence::ASSIGNMENT, true},
+        {TokenType::PLUS_ASSIGN, Precedence::ASSIGNMENT, true},
+        {TokenType::MINUS_ASSIGN, Precedence::ASSIGNMENT, true},
+        {TokenType::STAR_ASSIGN, Precedence::ASSIGNMENT, true},
+        {TokenType::SLASH_ASSIGN, Precedence::ASSIGNMENT, true},
+        {TokenType::PERCENT_ASSIGN, Precedence::ASSIGNMENT, true},
+        {TokenType::BW_AND_ASSIGN, Precedence::ASSIGNMENT, true},
+        {TokenType::BW_OR_ASSIGN, Precedence::ASSIGNMENT, true},
+        {TokenType::SHL_ASSIGN, Precedence::ASSIGNMENT, true},
+        {TokenType::SHR_ASSIGN, Precedence::ASSIGNMENT, true},
+        {TokenType::NOT_ASSIGN, Precedence::ASSIGNMENT, true},
+        {TokenType::XOR_ASSIGN, Precedence::ASSIGNMENT, true},
         {TokenType::DOT, Precedence::SCOPE_RESOLUTION},
         {TokenType::COLON_COLON, Precedence::SCOPE_RESOLUTION},
     });
 
-    std::ranges::sort(all_bindings, {}, &Binding::first);
+    std::ranges::sort(all_bindings, {}, &Binding::type);
     return all_bindings;
 }();
 
 constexpr auto get_binding(TokenType tt) noexcept -> Optional<Binding> {
-    const auto it = std::ranges::lower_bound(ALL_BINDINGS, tt, {}, &Binding::first);
-    if (it == ALL_BINDINGS.end() || it->first != tt) { return std::nullopt; }
+    const auto it = std::ranges::lower_bound(ALL_BINDINGS, tt, {}, &Binding::type);
+    if (it == ALL_BINDINGS.end() || it->type != tt) { return std::nullopt; }
     return Optional<Binding>{*it};
 }
 

--- a/packages/compiler/include/syntax/token.hpp
+++ b/packages/compiler/include/syntax/token.hpp
@@ -123,7 +123,7 @@ enum class TokenType : u8 {
     FUNCTION,
     VAR,
     CONST,
-    COMPTIME,
+    CONSTEXPR,
     STRUCT,
     ENUM,
     UNION,

--- a/packages/compiler/src/ast/statements/declaration.cpp
+++ b/packages/compiler/src/ast/statements/declaration.cpp
@@ -52,7 +52,7 @@ auto DeclStatement::parse(syntax::Parser& parser)
         }
     } else if ((modifiers_has(modifiers, DeclModifiers::CONSTANT) &&
                 !modifiers_has(modifiers, DeclModifiers::EXTERN)) ||
-               modifiers_has(modifiers, DeclModifiers::COMPTIME)) {
+               modifiers_has(modifiers, DeclModifiers::CONSTEXPR)) {
         // Constant decls must be declared with a value unless they are extern
         return make_parser_unexpected(syntax::ParserError::CONST_DECL_MISSING_VALUE, start_token);
     }

--- a/packages/compiler/src/syntax/lexer.cpp
+++ b/packages/compiler/src/syntax/lexer.cpp
@@ -15,23 +15,21 @@ Lexer::Snapshot::Snapshot(const Lexer& l) noexcept
 
 auto Lexer::reset(std::string_view input) noexcept -> void { *this = Lexer{input}; }
 
-auto Lexer::advance() noexcept -> syntax::Token {
+auto Lexer::advance() noexcept -> Token {
     skip_whitespace();
 
     const auto start_line = line_no_;
     const auto start_col  = col_no_;
 
-    syntax::Token token{{}, {}, start_line, start_col};
-    const auto    maybe_operator = read_operator();
+    Token      token{{}, {}, start_line, start_col};
+    const auto maybe_operator = read_operator();
 
     if (maybe_operator) {
-        if (maybe_operator->type == syntax::TokenType::END) { return *maybe_operator; }
+        if (maybe_operator->type == TokenType::END) { return *maybe_operator; }
         for (size_t i = 0; i < maybe_operator->slice.size(); ++i) { read_character(); }
 
-        if (maybe_operator->type == syntax::TokenType::COMMENT) { return read_comment(); }
-        if (maybe_operator->type == syntax::TokenType::MULTILINE_STRING) {
-            return read_multiline_string();
-        }
+        if (maybe_operator->type == TokenType::COMMENT) { return read_comment(); }
+        if (maybe_operator->type == TokenType::MULTILINE_STRING) { return read_multiline_string(); }
 
         return *maybe_operator;
     }
@@ -56,18 +54,18 @@ auto Lexer::advance() noexcept -> syntax::Token {
         return read_byte_literal();
     } else {
         token.slice = input_.substr(pos_, 1);
-        token.type  = syntax::TokenType::ILLEGAL;
+        token.type  = TokenType::ILLEGAL;
     }
 
     read_character();
     return token;
 }
 
-auto Lexer::consume() -> std::vector<syntax::Token> {
+auto Lexer::consume() -> std::vector<Token> {
     reset(input_);
 
-    std::vector<syntax::Token> tokens;
-    do { tokens.emplace_back(advance()); } while (tokens.back().type != syntax::TokenType::END);
+    std::vector<Token> tokens;
+    do { tokens.emplace_back(advance()); } while (tokens.back().type != TokenType::END);
 
     return tokens;
 }
@@ -76,16 +74,16 @@ auto Lexer::skip_whitespace() noexcept -> void {
     while (std::isspace(current_byte_)) { read_character(); }
 }
 
-auto Lexer::lu_builtin(std::string_view ident) noexcept -> syntax::TokenType {
+auto Lexer::lu_builtin(std::string_view ident) noexcept -> TokenType {
     return get_builtin(ident)
-        .transform([](const auto& keyword) noexcept -> syntax::TokenType { return keyword.second; })
-        .value_or(syntax::TokenType::ILLEGAL);
+        .transform([](const auto& keyword) noexcept -> TokenType { return keyword.second; })
+        .value_or(TokenType::ILLEGAL);
 }
 
-auto Lexer::lu_ident(std::string_view ident) noexcept -> syntax::TokenType {
+auto Lexer::lu_ident(std::string_view ident) noexcept -> TokenType {
     return get_keyword(ident)
-        .transform([](const auto& keyword) noexcept -> syntax::TokenType { return keyword.second; })
-        .value_or(syntax::TokenType::IDENT);
+        .transform([](const auto& keyword) noexcept -> TokenType { return keyword.second; })
+        .value_or(TokenType::IDENT);
 }
 
 auto Lexer::read_character(u8 n) noexcept -> void {
@@ -108,16 +106,14 @@ auto Lexer::read_character(u8 n) noexcept -> void {
     }
 }
 
-auto Lexer::read_operator() const noexcept -> Optional<syntax::Token> {
+auto Lexer::read_operator() const noexcept -> Optional<Token> {
     const auto start_line = line_no_;
     const auto start_col  = col_no_;
 
-    if (current_byte_ == '\0') {
-        return syntax::Token{syntax::TokenType::END, {}, start_line, start_col};
-    }
+    if (current_byte_ == '\0') { return Token{TokenType::END, {}, start_line, start_col}; }
 
     size_t max_len      = 0;
-    auto   matched_type = syntax::TokenType::ILLEGAL;
+    auto   matched_type = TokenType::ILLEGAL;
 
     // Try extending from length 1 up to the max operator size
     for (size_t len = 1; len <= MAX_OPERATOR_LEN && pos_ + len <= input_.size(); ++len) {
@@ -130,7 +126,7 @@ auto Lexer::read_operator() const noexcept -> Optional<syntax::Token> {
 
     // We cannot greedily consume the lexer here since the next token instruction handles that
     if (max_len == 0) { return std::nullopt; }
-    return syntax::Token{matched_type, input_.substr(pos_, max_len), start_line, start_col};
+    return Token{matched_type, input_.substr(pos_, max_len), start_line, start_col};
 }
 
 auto Lexer::read_ident(bool builtin) noexcept -> std::string_view {
@@ -165,7 +161,7 @@ constexpr auto suffix_has(NumberSuffix suffix, NumberSuffix flag) noexcept -> bo
     return static_cast<bool>(suffix & flag);
 }
 
-auto Lexer::read_number() noexcept -> syntax::Token {
+auto Lexer::read_number() noexcept -> Token {
     const auto start           = pos_;
     const auto start_line      = line_no_;
     const auto start_col       = col_no_;
@@ -236,8 +232,7 @@ auto Lexer::read_number() noexcept -> syntax::Token {
 
     // Quick non-base-10 length validation
     if (base != Base::DECIMAL && pos_ - start <= 2) {
-        return {
-            syntax::TokenType::ILLEGAL, input_.substr(start, pos_ - start), start_line, start_col};
+        return {TokenType::ILLEGAL, input_.substr(start, pos_ - start), start_line, start_col};
     }
 
     NumberSuffix suffix{};
@@ -266,7 +261,7 @@ auto Lexer::read_number() noexcept -> syntax::Token {
 
     // Total validation
     const auto length = pos_ - start;
-    auto       type{syntax::TokenType::ILLEGAL};
+    auto       type{TokenType::ILLEGAL};
     if (length == 0) { return {type, input_.substr(start, 1), start_line, start_col}; }
 
     if (input_[pos_ - 1] == '.') {
@@ -282,28 +277,28 @@ auto Lexer::read_number() noexcept -> syntax::Token {
         if (base != Base::DECIMAL) {
             return {type, input_.substr(start, length), start_line, start_col};
         }
-        type = forced_float ? syntax::TokenType::FLOAT : syntax::TokenType::DOUBLE;
+        type = forced_float ? TokenType::FLOAT : TokenType::DOUBLE;
     } else {
         // Use an offset to increment the actual token type based on its base and width
         auto offset = base_idx(base);
         if (std::to_underlying(suffix) == 0) {
-            type = syntax::TokenType::INT_2;
+            type = TokenType::INT_2;
         } else {
             if (suffix_has(suffix, NumberSuffix::WIDE)) {
-                type = syntax::TokenType::LINT_2;
+                type = TokenType::LINT_2;
             } else if (suffix_has(suffix, NumberSuffix::SIZE)) {
-                type = syntax::TokenType::ZINT_2;
+                type = TokenType::ZINT_2;
             } else {
-                type = syntax::TokenType::INT_2;
+                type = TokenType::INT_2;
             }
 
             // We can just bump the offset for unsigned
             if (suffix_has(suffix, NumberSuffix::UNSIGNED)) {
-                offset += std::to_underlying(syntax::TokenType::UINT_2) -
-                          std::to_underlying(syntax::TokenType::INT_2);
+                offset +=
+                    std::to_underlying(TokenType::UINT_2) - std::to_underlying(TokenType::INT_2);
             }
         }
-        type = static_cast<syntax::TokenType>(std::to_underlying(type) + offset);
+        type = static_cast<TokenType>(std::to_underlying(type) + offset);
     }
 
     return {type, input_.substr(start, length), start_line, start_col};
@@ -324,7 +319,7 @@ auto Lexer::read_escape() noexcept -> byte {
     }
 }
 
-auto Lexer::read_string() noexcept -> syntax::Token {
+auto Lexer::read_string() noexcept -> Token {
     const auto start      = pos_;
     const auto start_line = line_no_;
     const auto start_col  = col_no_;
@@ -337,7 +332,7 @@ auto Lexer::read_string() noexcept -> syntax::Token {
 
     if (current_byte_ == '\0') {
         return {
-            syntax::TokenType::ILLEGAL,
+            TokenType::ILLEGAL,
             input_.substr(start, pos_ - start),
             start_line,
             start_col,
@@ -345,11 +340,11 @@ auto Lexer::read_string() noexcept -> syntax::Token {
     }
     read_character();
 
-    return {syntax::TokenType::STRING, input_.substr(start, pos_ - start), start_line, start_col};
+    return {TokenType::STRING, input_.substr(start, pos_ - start), start_line, start_col};
 }
 
 // Reads a multiline string from the token, assuming the '\\' operator has been consumed
-auto Lexer::read_multiline_string() noexcept -> syntax::Token {
+auto Lexer::read_multiline_string() noexcept -> Token {
     const auto start      = pos_;
     const auto start_line = line_no_;
     const auto start_col  = col_no_;
@@ -390,7 +385,7 @@ auto Lexer::read_multiline_string() noexcept -> syntax::Token {
     }
 
     return {
-        syntax::TokenType::MULTILINE_STRING,
+        TokenType::MULTILINE_STRING,
         input_.substr(start, end_pos - start),
         start_line,
         start_col,
@@ -400,7 +395,7 @@ auto Lexer::read_multiline_string() noexcept -> syntax::Token {
 // Reads a byte literal returning an illegal token for malformed literals.
 //
 // Assumes that the surrounding single quotes have not been consumed.
-auto Lexer::read_byte_literal() noexcept -> syntax::Token {
+auto Lexer::read_byte_literal() noexcept -> Token {
     const auto start      = pos_;
     const auto start_line = line_no_;
     const auto start_col  = col_no_;
@@ -413,8 +408,7 @@ auto Lexer::read_byte_literal() noexcept -> syntax::Token {
     } else if (current_byte_ != '\'' && current_byte_ != '\n' && current_byte_ != '\r') {
         read_character();
     } else {
-        return {
-            syntax::TokenType::ILLEGAL, input_.substr(start, pos_ - start), start_line, start_col};
+        return {TokenType::ILLEGAL, input_.substr(start, pos_ - start), start_line, start_col};
     }
 
     // The next character MUST be closing ', otherwise illegally consume like a comment
@@ -432,7 +426,7 @@ auto Lexer::read_byte_literal() noexcept -> syntax::Token {
         }
 
         return {
-            syntax::TokenType::ILLEGAL,
+            TokenType::ILLEGAL,
             input_.substr(start, illegal_end - start),
             start_line,
             start_col,
@@ -440,17 +434,17 @@ auto Lexer::read_byte_literal() noexcept -> syntax::Token {
     }
     read_character();
 
-    return {syntax::TokenType::BYTE, input_.substr(start, pos_ - start), start_line, start_col};
+    return {TokenType::BYTE, input_.substr(start, pos_ - start), start_line, start_col};
 }
 
 // Reads a comment from the token, assuming the '//' operator has been consumed
-auto Lexer::read_comment() noexcept -> syntax::Token {
+auto Lexer::read_comment() noexcept -> Token {
     const auto start      = pos_;
     const auto start_line = line_no_;
     const auto start_col  = col_no_;
     while (current_byte_ != '\n' && current_byte_ != '\0') { read_character(); }
 
-    return {syntax::TokenType::COMMENT, input_.substr(start, pos_ - start), start_line, start_col};
+    return {TokenType::COMMENT, input_.substr(start, pos_ - start), start_line, start_col};
 }
 
 } // namespace porpoise::syntax

--- a/packages/compiler/src/syntax/parser.cpp
+++ b/packages/compiler/src/syntax/parser.cpp
@@ -16,16 +16,14 @@
 
 namespace porpoise::syntax {
 
-syntax::Parser::Checkpoint::Checkpoint(const syntax::Parser& parser) noexcept
+Parser::Checkpoint::Checkpoint(const Parser& parser) noexcept
     : snapshot_{parser.lexer_}, current_{parser.current_token_}, peek_{parser.peek_token_} {}
 
-auto syntax::Parser::reset(std::string_view input) noexcept -> void {
-    *this = syntax::Parser{input};
-}
+auto Parser::reset(std::string_view input) noexcept -> void { *this = Parser{input}; }
 
-auto syntax::Parser::advance(u8 times) noexcept -> const syntax::Token& {
+auto Parser::advance(u8 times) noexcept -> const Token& {
     for (u8 i = 0; i < times; ++i) {
-        if (current_token_.type == syntax::TokenType::END &&
+        if (current_token_.type == TokenType::END &&
             (input_.empty() && current_token_.is_at_start())) {
             break;
         }
@@ -36,19 +34,19 @@ auto syntax::Parser::advance(u8 times) noexcept -> const syntax::Token& {
     return current_token_;
 }
 
-auto syntax::Parser::consume() -> std::pair<ast::AST, Diagnostics> {
+auto Parser::consume() -> std::pair<ast::AST, Diagnostics> {
     reset(input_);
     ast::AST    ast;
     Diagnostics diagnostics;
 
-    while (!current_token_is(syntax::TokenType::END)) {
+    while (!current_token_is(TokenType::END)) {
         // Advance through any amount of semicolons
-        const auto skip = [](syntax::TokenType tt) { return tt == syntax::TokenType::SEMICOLON; };
+        const auto skip = [](TokenType tt) { return tt == TokenType::SEMICOLON; };
         if (skip(current_token_.type)) { while (skip(advance().type)); }
-        if (current_token_is(syntax::TokenType::END)) { break; }
+        if (current_token_is(TokenType::END)) { break; }
 
         // Comments are entirely discarded from the tree
-        if (!current_token_is(syntax::TokenType::COMMENT)) {
+        if (!current_token_is(TokenType::COMMENT)) {
             auto stmt = parse_statement();
             if (stmt) {
                 ast.emplace_back(std::move(*stmt));
@@ -56,12 +54,12 @@ auto syntax::Parser::consume() -> std::pair<ast::AST, Diagnostics> {
                 diagnostics.emplace_back(std::move(stmt.error()));
 
                 // Errors should advance up to next logical end to prevent useless errors
-                const auto stop_condition = [](syntax::TokenType tt) {
+                const auto stop_condition = [](TokenType tt) {
                     switch (tt) {
-                    case syntax::TokenType::RBRACE:
-                    case syntax::TokenType::SEMICOLON:
-                    case syntax::TokenType::END:       return true;
-                    default:                           return false;
+                    case TokenType::RBRACE:
+                    case TokenType::SEMICOLON:
+                    case TokenType::END:       return true;
+                    default:                   return false;
                     }
                 };
                 while (!stop_condition(advance().type));
@@ -73,8 +71,7 @@ auto syntax::Parser::consume() -> std::pair<ast::AST, Diagnostics> {
     return {std::move(ast), std::move(diagnostics)};
 }
 
-auto syntax::Parser::expect_peek(syntax::TokenType expected)
-    -> Expected<std::monostate, syntax::ParserDiagnostic> {
+auto Parser::expect_peek(TokenType expected) -> Expected<std::monostate, ParserDiagnostic> {
     if (peek_token_is(expected)) {
         advance();
         return {};
@@ -82,44 +79,47 @@ auto syntax::Parser::expect_peek(syntax::TokenType expected)
     return Unexpected{peek_error(expected)};
 }
 
-auto syntax::Parser::poll_current_precedence() const noexcept -> Precedence {
+auto Parser::poll_current_precedence() const noexcept -> std::pair<Precedence, Optional<Binding>> {
     return get_binding(current_token_.type)
-        .transform([](const auto& binding) { return binding.second; })
-        .value_or(Precedence::LOWEST);
+        .transform([](const auto& binding) {
+            return std::pair{binding.precedence, Optional<Binding>{binding}};
+        })
+        .value_or(std::pair{Precedence::LOWEST, std::nullopt});
 }
 
-auto syntax::Parser::poll_peek_precedence() const noexcept -> Precedence {
+auto Parser::poll_peek_precedence() const noexcept -> std::pair<Precedence, Optional<Binding>> {
     return get_binding(peek_token_.type)
-        .transform([](const auto& binding) { return binding.second; })
-        .value_or(Precedence::LOWEST);
+        .transform([](const auto& binding) {
+            return std::pair{binding.precedence, Optional<Binding>{binding}};
+        })
+        .value_or(std::pair{Precedence::LOWEST, std::nullopt});
 }
 
-auto syntax::Parser::parse_statement()
-    -> Expected<mem::Box<ast::Statement>, syntax::ParserDiagnostic> {
+auto Parser::parse_statement() -> Expected<mem::Box<ast::Statement>, ParserDiagnostic> {
     switch (current_token_.type) {
-    case syntax::TokenType::VAR:
-    case syntax::TokenType::CONST:
-    case syntax::TokenType::COMPTIME:
-    case syntax::TokenType::PUBLIC:
-    case syntax::TokenType::EXTERN:
-    case syntax::TokenType::EXPORT:     return ast::DeclStatement::parse(*this);
-    case syntax::TokenType::BREAK:
-    case syntax::TokenType::RETURN:
-    case syntax::TokenType::CONTINUE:   return ast::JumpStatement::parse(*this);
-    case syntax::TokenType::DEFER:      return ast::DeferStatement::parse(*this);
-    case syntax::TokenType::IMPORT:     return ast::ImportStatement::parse(*this);
-    case syntax::TokenType::LBRACE:     return ast::BlockStatement::parse(*this);
-    case syntax::TokenType::UNDERSCORE: return ast::DiscardStatement::parse(*this);
-    case syntax::TokenType::MODULE:     return ast::ModuleStatement::parse(*this);
-    case syntax::TokenType::USING:      return ast::UsingStatement::parse(*this);
-    default:                            return ast::ExpressionStatement::parse(*this);
+    case TokenType::VAR:
+    case TokenType::CONST:
+    case TokenType::CONSTEXPR:
+    case TokenType::PUBLIC:
+    case TokenType::EXTERN:
+    case TokenType::EXPORT:     return ast::DeclStatement::parse(*this);
+    case TokenType::BREAK:
+    case TokenType::RETURN:
+    case TokenType::CONTINUE:   return ast::JumpStatement::parse(*this);
+    case TokenType::DEFER:      return ast::DeferStatement::parse(*this);
+    case TokenType::IMPORT:     return ast::ImportStatement::parse(*this);
+    case TokenType::LBRACE:     return ast::BlockStatement::parse(*this);
+    case TokenType::UNDERSCORE: return ast::DiscardStatement::parse(*this);
+    case TokenType::MODULE:     return ast::ModuleStatement::parse(*this);
+    case TokenType::USING:      return ast::UsingStatement::parse(*this);
+    default:                    return ast::ExpressionStatement::parse(*this);
     }
 }
 
-auto syntax::Parser::parse_expression(Precedence precedence)
-    -> Expected<mem::Box<ast::Expression>, syntax::ParserDiagnostic> {
-    if (current_token_is(syntax::TokenType::END)) {
-        return make_parser_unexpected(syntax::ParserError::END_OF_TOKEN_STREAM, current_token_);
+auto Parser::parse_expression(Precedence precedence)
+    -> Expected<mem::Box<ast::Expression>, ParserDiagnostic> {
+    if (current_token_is(TokenType::END)) {
+        return make_parser_unexpected(ParserError::END_OF_TOKEN_STREAM, current_token_);
     }
 
     const auto& prefix = poll_prefix_fn(current_token_.type);
@@ -127,12 +127,12 @@ auto syntax::Parser::parse_expression(Precedence precedence)
         return make_parser_unexpected(fmt::format("No prefix parse function for {}({}) found",
                                                   magic_enum::enum_name(current_token_.type),
                                                   current_token_.slice),
-                                      syntax::ParserError::MISSING_PREFIX_PARSER,
+                                      ParserError::MISSING_PREFIX_PARSER,
                                       current_token_);
     }
     auto lhs_expression = TRY((*prefix)(*this));
 
-    while (!peek_token_is(syntax::TokenType::SEMICOLON) && precedence < poll_peek_precedence()) {
+    while (!peek_token_is(TokenType::SEMICOLON) && precedence < poll_peek_precedence().first) {
         const auto& infix = poll_infix_fn(peek_token_.type);
         if (!infix) { break; }
         advance();
@@ -142,8 +142,8 @@ auto syntax::Parser::parse_expression(Precedence precedence)
     return lhs_expression;
 }
 
-[[nodiscard]] auto syntax::Parser::parse_restricted_statement(syntax::ParserError error)
-    -> Expected<mem::Box<ast::Statement>, syntax::ParserDiagnostic> {
+[[nodiscard]] auto Parser::parse_restricted_statement(ParserError error)
+    -> Expected<mem::Box<ast::Statement>, ParserDiagnostic> {
     using namespace ast;
     auto clause = TRY(parse_statement());
 
@@ -154,9 +154,9 @@ auto syntax::Parser::parse_expression(Precedence precedence)
     return clause;
 }
 
-[[nodiscard]] auto syntax::Parser::try_parse_restricted_alternate(syntax::ParserError error)
-    -> Expected<Optional<mem::Box<ast::Statement>>, syntax::ParserDiagnostic> {
-    if (peek_token_is(syntax::TokenType::ELSE)) {
+[[nodiscard]] auto Parser::try_parse_restricted_alternate(ParserError error)
+    -> Expected<Optional<mem::Box<ast::Statement>>, ParserDiagnostic> {
+    if (peek_token_is(TokenType::ELSE)) {
         // Advance twice to actually look at the statement's first token
         advance(2);
         return TRY(parse_restricted_statement(error));
@@ -164,48 +164,48 @@ auto syntax::Parser::parse_expression(Precedence precedence)
     return std::nullopt;
 }
 
-using PrefixPair          = std::pair<syntax::TokenType, syntax::Parser::PrefixFn>;
-constexpr auto PREFIX_FNS = []() {
+using PrefixPair          = std::pair<TokenType, Parser::PrefixFn>;
+constexpr auto PREFIX_FNS = [] {
     constexpr auto initial_prefixes = std::to_array<PrefixPair>({
-        {syntax::TokenType::IDENT, ast::IdentifierExpression::parse},
-        {syntax::TokenType::BYTE, ast::ByteExpression::parse},
-        {syntax::TokenType::FLOAT, ast::FloatExpression::parse},
-        {syntax::TokenType::DOUBLE, ast::DoubleExpression::parse},
-        {syntax::TokenType::BANG, ast::UnaryExpression::parse},
-        {syntax::TokenType::NOT, ast::UnaryExpression::parse},
-        {syntax::TokenType::MINUS, ast::UnaryExpression::parse},
-        {syntax::TokenType::PLUS, ast::UnaryExpression::parse},
-        {syntax::TokenType::STAR, ast::DereferenceExpression::parse},
-        {syntax::TokenType::BW_AND, ast::ReferenceExpression::parse},
-        {syntax::TokenType::AND_MUT, ast::ReferenceExpression::parse},
-        {syntax::TokenType::DOT, ast::ImplicitAccessExpression::parse},
-        {syntax::TokenType::TRUE, ast::BoolExpression::parse},
-        {syntax::TokenType::FALSE, ast::BoolExpression::parse},
-        {syntax::TokenType::STRING, ast::StringExpression::parse},
-        {syntax::TokenType::MULTILINE_STRING, ast::StringExpression::parse},
-        {syntax::TokenType::LPAREN, ast::GroupedExpression::parse},
-        {syntax::TokenType::IF, ast::IfExpression::parse},
-        {syntax::TokenType::FUNCTION, ast::FunctionExpression::parse},
-        {syntax::TokenType::PACKED, ast::StructExpression::parse},
-        {syntax::TokenType::STRUCT, ast::StructExpression::parse},
-        {syntax::TokenType::UNION, ast::UnionExpression::parse},
-        {syntax::TokenType::ENUM, ast::EnumExpression::parse},
-        {syntax::TokenType::MATCH, ast::MatchExpression::parse},
-        {syntax::TokenType::LBRACKET, ast::ArrayExpression::parse},
-        {syntax::TokenType::FOR, ast::ForLoopExpression::parse},
-        {syntax::TokenType::WHILE, ast::WhileLoopExpression::parse},
-        {syntax::TokenType::DO, ast::DoWhileLoopExpression::parse},
-        {syntax::TokenType::LOOP, ast::InfiniteLoopExpression::parse},
+        {TokenType::IDENT, ast::IdentifierExpression::parse},
+        {TokenType::BYTE, ast::ByteExpression::parse},
+        {TokenType::FLOAT, ast::FloatExpression::parse},
+        {TokenType::DOUBLE, ast::DoubleExpression::parse},
+        {TokenType::BANG, ast::UnaryExpression::parse},
+        {TokenType::NOT, ast::UnaryExpression::parse},
+        {TokenType::MINUS, ast::UnaryExpression::parse},
+        {TokenType::PLUS, ast::UnaryExpression::parse},
+        {TokenType::STAR, ast::DereferenceExpression::parse},
+        {TokenType::BW_AND, ast::ReferenceExpression::parse},
+        {TokenType::AND_MUT, ast::ReferenceExpression::parse},
+        {TokenType::DOT, ast::ImplicitAccessExpression::parse},
+        {TokenType::TRUE, ast::BoolExpression::parse},
+        {TokenType::FALSE, ast::BoolExpression::parse},
+        {TokenType::STRING, ast::StringExpression::parse},
+        {TokenType::MULTILINE_STRING, ast::StringExpression::parse},
+        {TokenType::LPAREN, ast::GroupedExpression::parse},
+        {TokenType::IF, ast::IfExpression::parse},
+        {TokenType::FUNCTION, ast::FunctionExpression::parse},
+        {TokenType::PACKED, ast::StructExpression::parse},
+        {TokenType::STRUCT, ast::StructExpression::parse},
+        {TokenType::UNION, ast::UnionExpression::parse},
+        {TokenType::ENUM, ast::EnumExpression::parse},
+        {TokenType::MATCH, ast::MatchExpression::parse},
+        {TokenType::LBRACKET, ast::ArrayExpression::parse},
+        {TokenType::FOR, ast::ForLoopExpression::parse},
+        {TokenType::WHILE, ast::WhileLoopExpression::parse},
+        {TokenType::DO, ast::DoWhileLoopExpression::parse},
+        {TokenType::LOOP, ast::InfiniteLoopExpression::parse},
     });
 
-    constexpr auto total_ints = static_cast<usize>(syntax::TokenType::UZINT_16) -
-                                static_cast<usize>(syntax::TokenType::INT_2) + 1;
+    constexpr auto total_ints =
+        static_cast<usize>(TokenType::UZINT_16) - static_cast<usize>(TokenType::INT_2) + 1;
     std::array<PrefixPair, total_ints> int_prefixes;
     usize                              cursor = 0;
-    for (auto i = std::to_underlying(syntax::TokenType::INT_2);
-         i <= std::to_underlying(syntax::TokenType::UZINT_16);
+    for (auto i = std::to_underlying(TokenType::INT_2);
+         i <= std::to_underlying(TokenType::UZINT_16);
          ++i, ++cursor) {
-        const auto tt = static_cast<syntax::TokenType>(i);
+        const auto tt = static_cast<TokenType>(i);
         using namespace token_type;
         switch (to_int_category(tt)) {
         case IntegerCategory::SIGNED_BASE:
@@ -230,7 +230,7 @@ constexpr auto PREFIX_FNS = []() {
     }
 
     constexpr auto primitive_prefixes =
-        ALL_PRIMITIVES | std::views::transform([](syntax::TokenType tt) -> PrefixPair {
+        ALL_PRIMITIVES | std::views::transform([](TokenType tt) -> PrefixPair {
             return {tt, ast::IdentifierExpression::parse};
         });
 
@@ -251,72 +251,69 @@ constexpr auto PREFIX_FNS = []() {
     return prefix_fns;
 }();
 
-constexpr auto syntax::Parser::poll_prefix_fn(syntax::TokenType tt) noexcept
-    -> Optional<const PrefixFn&> {
+constexpr auto Parser::poll_prefix_fn(TokenType tt) noexcept -> Optional<const PrefixFn&> {
     const auto it = std::ranges::lower_bound(PREFIX_FNS, tt, {}, &PrefixPair::first);
     if (it == PREFIX_FNS.end() || it->first != tt) { return std::nullopt; }
     return Optional<const PrefixFn&>{it->second};
 }
 
-using InfixPair          = std::pair<syntax::TokenType, syntax::Parser::InfixFn>;
-constexpr auto INFIX_FNS = []() {
+using InfixPair          = std::pair<TokenType, Parser::InfixFn>;
+constexpr auto INFIX_FNS = [] {
     auto infix_fns = std::to_array<InfixPair>({
-        {syntax::TokenType::PLUS, ast::BinaryExpression::parse},
-        {syntax::TokenType::MINUS, ast::BinaryExpression::parse},
-        {syntax::TokenType::STAR, ast::BinaryExpression::parse},
-        {syntax::TokenType::SLASH, ast::BinaryExpression::parse},
-        {syntax::TokenType::PERCENT, ast::BinaryExpression::parse},
-        {syntax::TokenType::LT, ast::BinaryExpression::parse},
-        {syntax::TokenType::LT_EQ, ast::BinaryExpression::parse},
-        {syntax::TokenType::GT, ast::BinaryExpression::parse},
-        {syntax::TokenType::GT_EQ, ast::BinaryExpression::parse},
-        {syntax::TokenType::EQ, ast::BinaryExpression::parse},
-        {syntax::TokenType::NEQ, ast::BinaryExpression::parse},
-        {syntax::TokenType::BOOLEAN_AND, ast::BinaryExpression::parse},
-        {syntax::TokenType::BOOLEAN_OR, ast::BinaryExpression::parse},
-        {syntax::TokenType::BW_AND, ast::BinaryExpression::parse},
-        {syntax::TokenType::BW_OR, ast::BinaryExpression::parse},
-        {syntax::TokenType::XOR, ast::BinaryExpression::parse},
-        {syntax::TokenType::SHR, ast::BinaryExpression::parse},
-        {syntax::TokenType::SHL, ast::BinaryExpression::parse},
-        {syntax::TokenType::DOT, ast::DotExpression::parse},
-        {syntax::TokenType::DOT_DOT, ast::RangeExpression::parse},
-        {syntax::TokenType::DOT_DOT_EQ, ast::RangeExpression::parse},
-        {syntax::TokenType::LPAREN, ast::CallExpression::parse},
-        {syntax::TokenType::LBRACKET, ast::IndexExpression::parse},
-        {syntax::TokenType::ASSIGN, ast::AssignmentExpression::parse},
-        {syntax::TokenType::PLUS_ASSIGN, ast::AssignmentExpression::parse},
-        {syntax::TokenType::MINUS_ASSIGN, ast::AssignmentExpression::parse},
-        {syntax::TokenType::STAR_ASSIGN, ast::AssignmentExpression::parse},
-        {syntax::TokenType::SLASH_ASSIGN, ast::AssignmentExpression::parse},
-        {syntax::TokenType::PERCENT_ASSIGN, ast::AssignmentExpression::parse},
-        {syntax::TokenType::BW_AND_ASSIGN, ast::AssignmentExpression::parse},
-        {syntax::TokenType::BW_OR_ASSIGN, ast::AssignmentExpression::parse},
-        {syntax::TokenType::SHL_ASSIGN, ast::AssignmentExpression::parse},
-        {syntax::TokenType::SHR_ASSIGN, ast::AssignmentExpression::parse},
-        {syntax::TokenType::NOT_ASSIGN, ast::AssignmentExpression::parse},
-        {syntax::TokenType::XOR_ASSIGN, ast::AssignmentExpression::parse},
-        {syntax::TokenType::COLON_COLON, ast::ScopeResolutionExpression::parse},
+        {TokenType::PLUS, ast::BinaryExpression::parse},
+        {TokenType::MINUS, ast::BinaryExpression::parse},
+        {TokenType::STAR, ast::BinaryExpression::parse},
+        {TokenType::SLASH, ast::BinaryExpression::parse},
+        {TokenType::PERCENT, ast::BinaryExpression::parse},
+        {TokenType::LT, ast::BinaryExpression::parse},
+        {TokenType::LT_EQ, ast::BinaryExpression::parse},
+        {TokenType::GT, ast::BinaryExpression::parse},
+        {TokenType::GT_EQ, ast::BinaryExpression::parse},
+        {TokenType::EQ, ast::BinaryExpression::parse},
+        {TokenType::NEQ, ast::BinaryExpression::parse},
+        {TokenType::BOOLEAN_AND, ast::BinaryExpression::parse},
+        {TokenType::BOOLEAN_OR, ast::BinaryExpression::parse},
+        {TokenType::BW_AND, ast::BinaryExpression::parse},
+        {TokenType::BW_OR, ast::BinaryExpression::parse},
+        {TokenType::XOR, ast::BinaryExpression::parse},
+        {TokenType::SHR, ast::BinaryExpression::parse},
+        {TokenType::SHL, ast::BinaryExpression::parse},
+        {TokenType::DOT, ast::DotExpression::parse},
+        {TokenType::DOT_DOT, ast::RangeExpression::parse},
+        {TokenType::DOT_DOT_EQ, ast::RangeExpression::parse},
+        {TokenType::LPAREN, ast::CallExpression::parse},
+        {TokenType::LBRACKET, ast::IndexExpression::parse},
+        {TokenType::ASSIGN, ast::AssignmentExpression::parse},
+        {TokenType::PLUS_ASSIGN, ast::AssignmentExpression::parse},
+        {TokenType::MINUS_ASSIGN, ast::AssignmentExpression::parse},
+        {TokenType::STAR_ASSIGN, ast::AssignmentExpression::parse},
+        {TokenType::SLASH_ASSIGN, ast::AssignmentExpression::parse},
+        {TokenType::PERCENT_ASSIGN, ast::AssignmentExpression::parse},
+        {TokenType::BW_AND_ASSIGN, ast::AssignmentExpression::parse},
+        {TokenType::BW_OR_ASSIGN, ast::AssignmentExpression::parse},
+        {TokenType::SHL_ASSIGN, ast::AssignmentExpression::parse},
+        {TokenType::SHR_ASSIGN, ast::AssignmentExpression::parse},
+        {TokenType::NOT_ASSIGN, ast::AssignmentExpression::parse},
+        {TokenType::XOR_ASSIGN, ast::AssignmentExpression::parse},
+        {TokenType::COLON_COLON, ast::ScopeResolutionExpression::parse},
     });
 
     std::ranges::sort(infix_fns, {}, &InfixPair::first);
     return infix_fns;
 }();
 
-constexpr auto syntax::Parser::poll_infix_fn(syntax::TokenType tt) noexcept
-    -> Optional<const InfixFn&> {
+constexpr auto Parser::poll_infix_fn(TokenType tt) noexcept -> Optional<const InfixFn&> {
     const auto it = std::ranges::lower_bound(INFIX_FNS, tt, {}, &InfixPair::first);
     if (it == INFIX_FNS.end() || it->first != tt) { return std::nullopt; }
     return Optional<const InfixFn&>{it->second};
 }
 
-auto syntax::Parser::tt_mismatch_error(syntax::TokenType expected, const syntax::Token& actual)
-    -> syntax::ParserDiagnostic {
-    return syntax::ParserDiagnostic{fmt::format("Expected token {}, found {}",
-                                                magic_enum::enum_name(expected),
-                                                magic_enum::enum_name(actual.type)),
-                                    syntax::ParserError::UNEXPECTED_TOKEN,
-                                    actual};
+auto Parser::tt_mismatch_error(TokenType expected, const Token& actual) -> ParserDiagnostic {
+    return ParserDiagnostic{fmt::format("Expected token {}, found {}",
+                                        magic_enum::enum_name(expected),
+                                        magic_enum::enum_name(actual.type)),
+                            ParserError::UNEXPECTED_TOKEN,
+                            actual};
 }
 
 } // namespace porpoise::syntax

--- a/packages/compiler/src/syntax/token.cpp
+++ b/packages/compiler/src/syntax/token.cpp
@@ -28,53 +28,53 @@ auto digit_in_base(byte c, Base base) noexcept -> bool {
 
 namespace token_type {
 
-auto to_base(syntax::TokenType tt) noexcept -> Optional<Base> {
+auto to_base(TokenType tt) noexcept -> Optional<Base> {
     switch (tt) {
-    case syntax::TokenType::INT_2:
-    case syntax::TokenType::LINT_2:
-    case syntax::TokenType::ZINT_2:
-    case syntax::TokenType::UINT_2:
-    case syntax::TokenType::ULINT_2:
-    case syntax::TokenType::UZINT_2:  return Base::BINARY;
-    case syntax::TokenType::INT_8:
-    case syntax::TokenType::LINT_8:
-    case syntax::TokenType::ZINT_8:
-    case syntax::TokenType::UINT_8:
-    case syntax::TokenType::ULINT_8:
-    case syntax::TokenType::UZINT_8:  return Base::OCTAL;
-    case syntax::TokenType::INT_10:
-    case syntax::TokenType::LINT_10:
-    case syntax::TokenType::ZINT_10:
-    case syntax::TokenType::UINT_10:
-    case syntax::TokenType::ULINT_10:
-    case syntax::TokenType::UZINT_10: return Base::DECIMAL;
-    case syntax::TokenType::INT_16:
-    case syntax::TokenType::LINT_16:
-    case syntax::TokenType::ZINT_16:
-    case syntax::TokenType::UINT_16:
-    case syntax::TokenType::ULINT_16:
-    case syntax::TokenType::UZINT_16: return Base::HEXADECIMAL;
-    default:                          return std::nullopt;
+    case TokenType::INT_2:
+    case TokenType::LINT_2:
+    case TokenType::ZINT_2:
+    case TokenType::UINT_2:
+    case TokenType::ULINT_2:
+    case TokenType::UZINT_2:  return Base::BINARY;
+    case TokenType::INT_8:
+    case TokenType::LINT_8:
+    case TokenType::ZINT_8:
+    case TokenType::UINT_8:
+    case TokenType::ULINT_8:
+    case TokenType::UZINT_8:  return Base::OCTAL;
+    case TokenType::INT_10:
+    case TokenType::LINT_10:
+    case TokenType::ZINT_10:
+    case TokenType::UINT_10:
+    case TokenType::ULINT_10:
+    case TokenType::UZINT_10: return Base::DECIMAL;
+    case TokenType::INT_16:
+    case TokenType::LINT_16:
+    case TokenType::ZINT_16:
+    case TokenType::UINT_16:
+    case TokenType::ULINT_16:
+    case TokenType::UZINT_16: return Base::HEXADECIMAL;
+    default:                  return std::nullopt;
     }
 }
 
-auto misc_from_char(byte c) noexcept -> Optional<syntax::TokenType> {
+auto misc_from_char(byte c) noexcept -> Optional<TokenType> {
     switch (c) {
-    case ',': return syntax::TokenType::COMMA;
-    case ':': return syntax::TokenType::COLON;
-    case ';': return syntax::TokenType::SEMICOLON;
-    case '(': return syntax::TokenType::LPAREN;
-    case ')': return syntax::TokenType::RPAREN;
-    case '{': return syntax::TokenType::LBRACE;
-    case '}': return syntax::TokenType::RBRACE;
-    case '[': return syntax::TokenType::LBRACKET;
-    case ']': return syntax::TokenType::RBRACKET;
-    case '_': return syntax::TokenType::UNDERSCORE;
+    case ',': return TokenType::COMMA;
+    case ':': return TokenType::COLON;
+    case ';': return TokenType::SEMICOLON;
+    case '(': return TokenType::LPAREN;
+    case ')': return TokenType::RPAREN;
+    case '{': return TokenType::LBRACE;
+    case '}': return TokenType::RBRACE;
+    case '[': return TokenType::LBRACKET;
+    case ']': return TokenType::RBRACKET;
+    case '_': return TokenType::UNDERSCORE;
     default:  return std::nullopt;
     }
 }
 
-using SuffixMapping                = std::pair<bool (*)(syntax::TokenType), usize>;
+using SuffixMapping                = std::pair<bool (*)(TokenType), usize>;
 constexpr auto INT_SUFFIX_MAPPINGS = std::to_array<SuffixMapping>({
     {is_signed_int, 0},
     {is_signed_long_int, 1},
@@ -84,9 +84,9 @@ constexpr auto INT_SUFFIX_MAPPINGS = std::to_array<SuffixMapping>({
     {is_usize_int, 2},
 });
 
-auto suffix_length(syntax::TokenType tt) noexcept -> usize {
-    if (tt == syntax::TokenType::FLOAT) { return 1; }
-    if (tt < syntax::TokenType::INT_2 || tt > syntax::TokenType::UZINT_16) { return 0; }
+auto suffix_length(TokenType tt) noexcept -> usize {
+    if (tt == TokenType::FLOAT) { return 1; }
+    if (tt < TokenType::INT_2 || tt > TokenType::UZINT_16) { return 0; }
     return std::ranges::find_if(
                INT_SUFFIX_MAPPINGS,
                [tt](auto in_range) { return in_range(tt); },
@@ -96,13 +96,13 @@ auto suffix_length(syntax::TokenType tt) noexcept -> usize {
 
 } // namespace token_type
 
-auto syntax::Token::promote() const -> Expected<std::string, Diagnostic<TokenError>> {
-    if (type != syntax::TokenType::STRING && type != syntax::TokenType::MULTILINE_STRING) {
+auto Token::promote() const -> Expected<std::string, Diagnostic<TokenError>> {
+    if (type != TokenType::STRING && type != TokenType::MULTILINE_STRING) {
         return Unexpected{Diagnostic{TokenError::NON_STRING_TOKEN, line, column}};
     }
 
     // Here we can just trim off the start and finish of the string
-    if (type == syntax::TokenType::STRING) {
+    if (type == TokenType::STRING) {
         if (slice.size() < 2) {
             return Unexpected{Diagnostic{TokenError::UNEXPECTED_CHAR, line, column}};
         }
@@ -132,17 +132,17 @@ auto syntax::Token::promote() const -> Expected<std::string, Diagnostic<TokenErr
     return builder;
 }
 
-auto syntax::Token::is_primitive() const noexcept -> bool {
+auto Token::is_primitive() const noexcept -> bool {
     return std::ranges::contains(ALL_PRIMITIVES, type);
 }
 
-auto syntax::Token::is_builtin() const noexcept -> bool {
-    return std::ranges::contains(ALL_BUILTINS, type, &syntax::Keyword::second);
+auto Token::is_builtin() const noexcept -> bool {
+    return std::ranges::contains(ALL_BUILTINS, type, &Keyword::second);
 }
 
-auto syntax::Token::is_valid_ident() const noexcept -> bool {
-    return type == syntax::TokenType::IDENT || type == syntax::TokenType::NORETURN ||
-           type == syntax::TokenType::TYPE_TYPE || is_primitive() || is_builtin();
+auto Token::is_valid_ident() const noexcept -> bool {
+    return type == TokenType::IDENT || type == TokenType::NORETURN ||
+           type == TokenType::TYPE_TYPE || is_primitive() || is_builtin();
 }
 
 } // namespace porpoise::syntax

--- a/packages/compiler/tests/ast/dump.inc
+++ b/packages/compiler/tests/ast/dump.inc
@@ -45,7 +45,7 @@ DiscardStatement
     └─ Enumerations:
         └─ Name: IdentifierExpression: RED
 DeclStatement (SIZE)
-├─ Modifiers: COMPTIME
+├─ Modifiers: CONSTEXPR
 ├─ Type: (inferred)
 └─ Value: USizeIntegerExpression: 2
 BlockStatement

--- a/packages/compiler/tests/ast/expressions/test_infix.cpp
+++ b/packages/compiler/tests/ast/expressions/test_infix.cpp
@@ -13,6 +13,8 @@
 
 #include "syntax/operators.hpp"
 
+#include "array.hpp"
+
 namespace porpoise::tests {
 
 namespace operators = syntax::operators;
@@ -65,6 +67,45 @@ TEST_CASE("Assignment expressions") {
         operators::XOR_ASSIGN,
     };
     helpers::test_infix_op_list<ast::AssignmentExpression>(ops);
+}
+
+TEST_CASE("Assignment operator right associativity") {
+    const auto test_assignment_assoc = [](std::pair<syntax::Operator, syntax::Operator> ops) {
+        const auto input = fmt::format("a {} b {} c;", ops.first.first, ops.second.first);
+        helpers::test_infix_expr<ast::AssignmentExpression>(
+            input,
+            helpers::ident_from("a"),
+            ops.first.second,
+            ast::AssignmentExpression{
+                syntax::Token{syntax::TokenType::IDENT, "b"},
+                helpers::make_ident("b"),
+                ops.second.second,
+                helpers::make_ident("c"),
+            });
+    };
+
+    const std::array assignment_ops{
+        operators::ASSIGN,
+        operators::PLUS_ASSIGN,
+        operators::MINUS_ASSIGN,
+        operators::STAR_ASSIGN,
+        operators::SLASH_ASSIGN,
+        operators::PERCENT_ASSIGN,
+        operators::BW_AND_ASSIGN,
+        operators::BW_OR_ASSIGN,
+        operators::SHL_ASSIGN,
+        operators::SHR_ASSIGN,
+        operators::NOT_ASSIGN,
+        operators::XOR_ASSIGN,
+    };
+
+    SECTION("Same operator") {
+        for (const auto& op : assignment_ops) { test_assignment_assoc({op, op}); }
+    }
+
+    SECTION("Combinations") {
+        for (const auto& ops : array::combinations(assignment_ops)) { test_assignment_assoc(ops); }
+    }
 }
 
 TEST_CASE("Binary expressions") {

--- a/packages/compiler/tests/ast/statements/test_declaration.cpp
+++ b/packages/compiler/tests/ast/statements/test_declaration.cpp
@@ -54,16 +54,16 @@ TEST_CASE("Explicit non-primitive declaration") {
         });
 }
 
-TEST_CASE("Implicit comptime declaration") {
+TEST_CASE("Constexpr declaration") {
     helpers::test_stmt(
-        "comptime SIZE := 2uz;",
+        "constexpr SIZE := 2uz;",
         ast::DeclStatement{
-            syntax::Token{keywords::COMPTIME},
+            syntax::Token{keywords::CONSTEXPR},
             helpers::make_ident("SIZE"),
             mem::make_box<ast::TypeExpression>(syntax::Token{operators::WALRUS}, std::nullopt),
             mem::make_box<ast::USizeIntegerExpression>(
                 syntax::Token{syntax::TokenType::UZINT_10, "2uz"}, 2uz),
-            ast::DeclModifiers::COMPTIME,
+            ast::DeclModifiers::CONSTEXPR,
         });
 }
 
@@ -134,27 +134,27 @@ static auto test_decl_fail(std::initializer_list<syntax::Keyword> modifiers,
 }
 
 TEST_CASE("Mutability restrictions") {
-    const auto contending_mut = std::array{keywords::COMPTIME, keywords::VAR, keywords::CONST};
+    const std::array contending_mut{keywords::CONSTEXPR, keywords::VAR, keywords::CONST};
     for (const auto& mut : array::combinations(contending_mut)) {
         test_decl_fail({mut.first, mut.second},
                        syntax::ParserDiagnostic{syntax::ParserError::ILLEGAL_DECL_MODIFIERS, 1, 1});
     }
-    test_decl_fail({keywords::COMPTIME, keywords::VAR, keywords::CONST},
+    test_decl_fail({keywords::CONSTEXPR, keywords::VAR, keywords::CONST},
                    syntax::ParserDiagnostic{syntax::ParserError::ILLEGAL_DECL_MODIFIERS, 1, 1});
 }
 
-TEST_CASE("Comptime restrictions") {
-    const auto contending_mut = std::array{keywords::EXTERN, keywords::COMPTIME};
+TEST_CASE("CONSTEXPR restrictions") {
+    const std::array contending_mut{keywords::EXTERN, keywords::CONSTEXPR};
     for (const auto& mut : array::combinations(contending_mut)) {
         test_decl_fail({mut.first, mut.second},
                        syntax::ParserDiagnostic{syntax::ParserError::ILLEGAL_DECL_MODIFIERS, 1, 1});
     }
-    test_decl_fail({keywords::EXTERN, keywords::COMPTIME},
+    test_decl_fail({keywords::EXTERN, keywords::CONSTEXPR},
                    syntax::ParserDiagnostic{syntax::ParserError::ILLEGAL_DECL_MODIFIERS, 1, 1});
 }
 
 TEST_CASE("ABI/Linkage restrictions") {
-    const auto contending_mut = std::array{keywords::EXTERN, keywords::EXPORT};
+    const std::array contending_mut{keywords::EXTERN, keywords::EXPORT};
     for (const auto& mut : array::combinations(contending_mut)) {
         test_decl_fail({mut.first, mut.second},
                        syntax::ParserDiagnostic{syntax::ParserError::ILLEGAL_DECL_MODIFIERS, 1, 1});
@@ -174,7 +174,7 @@ TEST_CASE("Constant requirements") {
     test_decl_fail({keywords::CONST},
                    syntax::ParserDiagnostic{syntax::ParserError::CONST_DECL_MISSING_VALUE, 1, 1},
                    "a: int;");
-    test_decl_fail({keywords::COMPTIME},
+    test_decl_fail({keywords::CONSTEXPR},
                    syntax::ParserDiagnostic{syntax::ParserError::CONST_DECL_MISSING_VALUE, 1, 1},
                    "a: int;");
 }

--- a/packages/compiler/tests/ast/test_dumper.cpp
+++ b/packages/compiler/tests/ast/test_dumper.cpp
@@ -19,7 +19,7 @@ constexpr std::string_view input{R"(
     import std;
     import "ast/node.p" as node;
     _ = enum { RED };
-    comptime SIZE := 2uz;
+    constexpr SIZE := 2uz;
     { a; b; 2; c; };
     while (true) : (i += 1) {a;} else return b;
     var f_ptr: *fn(&a, b: *mut B): &[0x2uz][N]*E;

--- a/packages/core/tests/test_array.cpp
+++ b/packages/core/tests/test_array.cpp
@@ -22,9 +22,9 @@ TEST_CASE("Array concatenation") {
 }
 
 TEST_CASE("Array combinations") {
-    constexpr auto A        = std::array{0, 1, 2};
-    constexpr auto expected = std::to_array<std::pair<i32, i32>>({{0, 1}, {0, 2}, {1, 2}});
-    constexpr auto actual   = array::combinations<i32>(A);
+    constexpr std::array A{0, 1, 2};
+    constexpr auto       expected = std::to_array<std::pair<i32, i32>>({{0, 1}, {0, 2}, {1, 2}});
+    constexpr auto       actual   = array::combinations<i32>(A);
     CHECK(std::ranges::equal(expected, actual));
 }
 


### PR DESCRIPTION
## Description

Closes #54. Also renames comptime keyword to constexpr while keeping its use the same. A zig user may see `comptime` and think it behaves like zig, but this is not the case. It is just a marker for compile time constants and cannot be used to run arbitrary code at compile time. There's also no need to include this keyword for parameters since type params are implicitly compile time restricted.

## Additional Context:

Relatively small fix, addressing a newly encountered bug. Also allows for more specific operators (like power/exponent) to be added in the future if needed, though I don't know if porpoise is the place for this.
