### PR TITLE
Bring syntax tests up to the standard of the rest of the test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,4 +130,4 @@ Project Link: [https://github.com/trevorswan11/porpoise](https://github.com/trev
 - [Zig](https://ziglang.org/)'s community, language features, and compiler source code
 - [Rust](https://rust-lang.org/)'s language features and philosophy
 - [cppreference](https://www.cppreference.com/)'s extensive C++ language documentation
-- [Thorsten Ball](https://store.thorstenball.com/)'s "Writing an Interpreter/Compiler in Go" two-book series
+- [Thorsten Ball](https://thorstenball.com/)'s "Writing an Interpreter/Compiler in Go" two-book series

--- a/lib/compiler/include/syntax/token.hpp
+++ b/lib/compiler/include/syntax/token.hpp
@@ -289,6 +289,8 @@ auto suffix_length(TokenType tt) noexcept -> usize;
 
 } // namespace token_type
 
+using TokenDiagnostic = Diagnostic<TokenError>;
+
 struct Token {
     TokenType        type{};
     std::string_view slice{};
@@ -306,7 +308,7 @@ struct Token {
         : type{tok.second}, slice{tok.first} {}
 
     [[nodiscard]] auto is_at_start() const noexcept -> bool { return line == 0 && column == 0; }
-    [[nodiscard]] auto promote() const -> Expected<std::string, Diagnostic<TokenError>>;
+    [[nodiscard]] auto promote() const -> Expected<std::string, TokenDiagnostic>;
     auto               is_primitive() const noexcept -> bool;
     auto               is_builtin() const noexcept -> bool;
 

--- a/lib/compiler/src/syntax/token.cpp
+++ b/lib/compiler/src/syntax/token.cpp
@@ -96,7 +96,7 @@ auto suffix_length(TokenType tt) noexcept -> usize {
 
 } // namespace token_type
 
-auto Token::promote() const -> Expected<std::string, Diagnostic<TokenError>> {
+auto Token::promote() const -> Expected<std::string, TokenDiagnostic> {
     if (type != TokenType::STRING && type != TokenType::MULTILINE_STRING) {
         return Unexpected{Diagnostic{TokenError::NON_STRING_TOKEN, line, column}};
     }

--- a/lib/compiler/src/syntax/token.cpp
+++ b/lib/compiler/src/syntax/token.cpp
@@ -98,13 +98,13 @@ auto suffix_length(TokenType tt) noexcept -> usize {
 
 auto Token::promote() const -> Expected<std::string, TokenDiagnostic> {
     if (type != TokenType::STRING && type != TokenType::MULTILINE_STRING) {
-        return Unexpected{Diagnostic{TokenError::NON_STRING_TOKEN, line, column}};
+        return Unexpected{TokenDiagnostic{TokenError::NON_STRING_TOKEN, line, column}};
     }
 
     // Here we can just trim off the start and finish of the string
     if (type == TokenType::STRING) {
         if (slice.size() < 2) {
-            return Unexpected{Diagnostic{TokenError::UNEXPECTED_CHAR, line, column}};
+            return Unexpected{TokenDiagnostic{TokenError::UNEXPECTED_CHAR, line, column}};
         }
         return std::string{slice.begin() + 1, slice.end() - 1};
     }

--- a/lib/compiler/tests/syntax/test_lexer.cpp
+++ b/lib/compiler/tests/syntax/test_lexer.cpp
@@ -1,3 +1,4 @@
+#include <initializer_list>
 #include <ranges>
 #include <string_view>
 #include <utility>
@@ -14,7 +15,25 @@ using namespace syntax;
 
 using ExpectedLexeme = std::pair<TokenType, std::string_view>;
 
-TEST_CASE("Illegal characters") {
+namespace helpers {
+
+auto test_lexer(std::string_view input, std::initializer_list<ExpectedLexeme> expecteds) -> void {
+    Lexer l{input};
+    for (const auto& [expected_tok, expected_slice] : expecteds) {
+        const auto token = l.advance();
+        CHECK(expected_tok == token.type);
+        CHECK(expected_slice == token.slice);
+    }
+
+    // Should be true regardless of caller putting END in their list
+    const auto& end_tok = l.advance();
+    CHECK(end_tok.type == TokenType::END);
+    CHECK(end_tok.slice == "");
+}
+
+} // namespace helpers
+
+TEST_CASE("Lexing illegal characters") {
     Lexer      l{"月😭🎶"};
     const auto tokens = l.consume();
 
@@ -34,160 +53,119 @@ TEST_CASE("Lexer over-consumption") {
     for (size_t i = 0; i < 100; ++i) { CHECK(l.advance().type == TokenType::END); }
 }
 
-TEST_CASE("Basic next token and Lexer consuming") {
-    SECTION("Symbols Only") {
-        Lexer l{"=+(){}[],;: !-/*<>_"};
-
-        const auto expecteds = std::to_array<ExpectedLexeme>({
-            {TokenType::ASSIGN, "="},    {TokenType::PLUS, "+"},     {TokenType::LPAREN, "("},
-            {TokenType::RPAREN, ")"},    {TokenType::LBRACE, "{"},   {TokenType::RBRACE, "}"},
-            {TokenType::LBRACKET, "["},  {TokenType::RBRACKET, "]"}, {TokenType::COMMA, ","},
-            {TokenType::SEMICOLON, ";"}, {TokenType::COLON, ":"},    {TokenType::BANG, "!"},
-            {TokenType::MINUS, "-"},     {TokenType::SLASH, "/"},    {TokenType::STAR, "*"},
-            {TokenType::LT, "<"},        {TokenType::GT, ">"},       {TokenType::UNDERSCORE, "_"},
-            {TokenType::END, ""},
-        });
-
-        for (const auto& [expected_tok, expected_slice] : expecteds) {
-            const auto token = l.advance();
-            CHECK(expected_tok == token.type);
-            CHECK(expected_slice == token.slice);
-        }
-    }
-
-    SECTION("Naive language snippet") {
-        const std::string_view input{"const five := 5;\n"
-                                     "var ten := 10;\n\n"
-                                     "var add := fn(x, y) {\n"
-                                     "   x + y;\n"
-                                     "};\n\n"
-                                     "var result := add(five, ten);\n"
-                                     "var four_and_some := 4.2;"};
-        Lexer                  l{input};
-
-        const auto expecteds = std::to_array<ExpectedLexeme>({
-            {TokenType::CONST, "const"}, {TokenType::IDENT, "five"},
-            {TokenType::WALRUS, ":="},   {TokenType::INT_10, "5"},
-            {TokenType::SEMICOLON, ";"}, {TokenType::VAR, "var"},
-            {TokenType::IDENT, "ten"},   {TokenType::WALRUS, ":="},
-            {TokenType::INT_10, "10"},   {TokenType::SEMICOLON, ";"},
-            {TokenType::VAR, "var"},     {TokenType::IDENT, "add"},
-            {TokenType::WALRUS, ":="},   {TokenType::FUNCTION, "fn"},
-            {TokenType::LPAREN, "("},    {TokenType::IDENT, "x"},
-            {TokenType::COMMA, ","},     {TokenType::IDENT, "y"},
-            {TokenType::RPAREN, ")"},    {TokenType::LBRACE, "{"},
-            {TokenType::IDENT, "x"},     {TokenType::PLUS, "+"},
-            {TokenType::IDENT, "y"},     {TokenType::SEMICOLON, ";"},
-            {TokenType::RBRACE, "}"},    {TokenType::SEMICOLON, ";"},
-            {TokenType::VAR, "var"},     {TokenType::IDENT, "result"},
-            {TokenType::WALRUS, ":="},   {TokenType::IDENT, "add"},
-            {TokenType::LPAREN, "("},    {TokenType::IDENT, "five"},
-            {TokenType::COMMA, ","},     {TokenType::IDENT, "ten"},
-            {TokenType::RPAREN, ")"},    {TokenType::SEMICOLON, ";"},
-            {TokenType::VAR, "var"},     {TokenType::IDENT, "four_and_some"},
-            {TokenType::WALRUS, ":="},   {TokenType::F64, "4.2"},
-            {TokenType::SEMICOLON, ";"}, {TokenType::END, ""},
-        });
-
-        Lexer      l_accumulator{input};
-        const auto accumulated_tokens = l_accumulator.consume();
-        l_accumulator.reset(input);
-        const auto reset_acc = l_accumulator.consume();
-
-        for (size_t i = 0; i < expecteds.size(); ++i) {
-            const auto& [expected_tok, expected_slice] = expecteds[i];
-            const auto token                           = l.advance();
-            const auto accumulated_token               = accumulated_tokens[i];
-            const auto reset                           = reset_acc[i];
-
-            CHECK(expected_tok == token.type);
-            CHECK(expected_tok == accumulated_token.type);
-            CHECK(expected_slice == token.slice);
-            CHECK(expected_slice == accumulated_token.slice);
-            CHECK(accumulated_token == reset);
-        }
-    }
+TEST_CASE("Lexing symbols") {
+    helpers::test_lexer("=+(){}[],;: !-/*<>_",
+                        {
+                            {TokenType::ASSIGN, "="},
+                            {TokenType::PLUS, "+"},
+                            {TokenType::LPAREN, "("},
+                            {TokenType::RPAREN, ")"},
+                            {TokenType::LBRACE, "{"},
+                            {TokenType::RBRACE, "}"},
+                            {TokenType::LBRACKET, "["},
+                            {TokenType::RBRACKET, "]"},
+                            {TokenType::COMMA, ","},
+                            {TokenType::SEMICOLON, ";"},
+                            {TokenType::COLON, ":"},
+                            {TokenType::BANG, "!"},
+                            {TokenType::MINUS, "-"},
+                            {TokenType::SLASH, "/"},
+                            {TokenType::STAR, "*"},
+                            {TokenType::LT, "<"},
+                            {TokenType::GT, ">"},
+                            {TokenType::UNDERSCORE, "_"},
+                        });
 }
 
-TEST_CASE("Base-10 ints and floats") {
-    SECTION("Correct numbers") {
-        Lexer l{"0 123 3.14 42.0 1e20 1.e-3 2.3901E4f 1e."};
-
-        const auto expecteds = std::to_array<ExpectedLexeme>({
-            {TokenType::INT_10, "0"},
-            {TokenType::INT_10, "123"},
-            {TokenType::F64, "3.14"},
-            {TokenType::F64, "42.0"},
-            {TokenType::F64, "1e20"},
-            {TokenType::F64, "1.e-3"},
-            {TokenType::F32, "2.3901E4f"},
-            {TokenType::INT_10, "1"},
-            {TokenType::IDENT, "e"},
-            {TokenType::DOT, "."},
-            {TokenType::END, ""},
-        });
-
-        for (const auto& [expected_tt, expected_slice] : expecteds) {
-            const auto token = l.advance();
-            CHECK(expected_tt == token.type);
-            CHECK(expected_slice == token.slice);
-        }
-    }
-
-    SECTION("Illegal Floats") {
-        Lexer l{".0 1..2 3.4.5 3.4u 5f"};
-
-        const auto expecteds = std::to_array<ExpectedLexeme>({
-            {TokenType::DOT, "."},
-            {TokenType::INT_10, "0"},
-            {TokenType::INT_10, "1"},
-            {TokenType::DOT_DOT, ".."},
-            {TokenType::INT_10, "2"},
-            {TokenType::F64, "3.4"},
-            {TokenType::DOT, "."},
-            {TokenType::INT_10, "5"},
-            {TokenType::F64, "3.4"},
-            {TokenType::IDENT, "u"},
-            {TokenType::F32, "5f"},
-            {TokenType::END, ""},
-        });
-
-        for (const auto& [expected_tt, expected_slice] : expecteds) {
-            const auto token = l.advance();
-            CHECK(expected_tt == token.type);
-            CHECK(expected_slice == token.slice);
-        }
-    }
+TEST_CASE("Lexing basic language snippet") {
+    helpers::test_lexer("const five := 5;\n"
+                        "var ten := 10;\n\n"
+                        "var add := fn(x: i32, y: i32): i32 {\n"
+                        "   return x + y;\n"
+                        "};\n\n"
+                        "var result := add(five, ten);\n"
+                        "var fs: f64 = 4.2;",
+                        {
+                            {TokenType::CONST, "const"},   {TokenType::IDENT, "five"},
+                            {TokenType::WALRUS, ":="},     {TokenType::INT_10, "5"},
+                            {TokenType::SEMICOLON, ";"},   {TokenType::VAR, "var"},
+                            {TokenType::IDENT, "ten"},     {TokenType::WALRUS, ":="},
+                            {TokenType::INT_10, "10"},     {TokenType::SEMICOLON, ";"},
+                            {TokenType::VAR, "var"},       {TokenType::IDENT, "add"},
+                            {TokenType::WALRUS, ":="},     {TokenType::FUNCTION, "fn"},
+                            {TokenType::LPAREN, "("},      {TokenType::IDENT, "x"},
+                            {TokenType::COLON, ":"},       {TokenType::I32_TYPE, "i32"},
+                            {TokenType::COMMA, ","},       {TokenType::IDENT, "y"},
+                            {TokenType::COLON, ":"},       {TokenType::I32_TYPE, "i32"},
+                            {TokenType::RPAREN, ")"},      {TokenType::COLON, ":"},
+                            {TokenType::I32_TYPE, "i32"},  {TokenType::LBRACE, "{"},
+                            {TokenType::RETURN, "return"}, {TokenType::IDENT, "x"},
+                            {TokenType::PLUS, "+"},        {TokenType::IDENT, "y"},
+                            {TokenType::SEMICOLON, ";"},   {TokenType::RBRACE, "}"},
+                            {TokenType::SEMICOLON, ";"},   {TokenType::VAR, "var"},
+                            {TokenType::IDENT, "result"},  {TokenType::WALRUS, ":="},
+                            {TokenType::IDENT, "add"},     {TokenType::LPAREN, "("},
+                            {TokenType::IDENT, "five"},    {TokenType::COMMA, ","},
+                            {TokenType::IDENT, "ten"},     {TokenType::RPAREN, ")"},
+                            {TokenType::SEMICOLON, ";"},   {TokenType::VAR, "var"},
+                            {TokenType::IDENT, "fs"},      {TokenType::COLON, ":"},
+                            {TokenType::F64_TYPE, "f64"},  {TokenType::ASSIGN, "="},
+                            {TokenType::F64, "4.2"},       {TokenType::SEMICOLON, ";"},
+                        });
 }
 
-TEST_CASE("Integer base variants") {
-    SECTION("Signed integer variants") {
-        Lexer l{"0b1010 0o17 0O17 42 0x2A 0X2A 0b 0x 0o"};
+TEST_CASE("Lexing numbers") {
+    helpers::test_lexer("0 123 3.14 42.0 1e20 1.e-3 2.3901E4f 1e.",
+                        {
+                            {TokenType::INT_10, "0"},
+                            {TokenType::INT_10, "123"},
+                            {TokenType::F64, "3.14"},
+                            {TokenType::F64, "42.0"},
+                            {TokenType::F64, "1e20"},
+                            {TokenType::F64, "1.e-3"},
+                            {TokenType::F32, "2.3901E4f"},
+                            {TokenType::INT_10, "1"},
+                            {TokenType::IDENT, "e"},
+                            {TokenType::DOT, "."},
+                        });
+}
 
-        const auto expecteds = std::to_array<ExpectedLexeme>({
-            {TokenType::INT_2, "0b1010"},
-            {TokenType::INT_8, "0o17"},
-            {TokenType::INT_8, "0O17"},
-            {TokenType::INT_10, "42"},
-            {TokenType::INT_16, "0x2A"},
-            {TokenType::INT_16, "0X2A"},
-            {TokenType::ILLEGAL, "0b"},
-            {TokenType::ILLEGAL, "0x"},
-            {TokenType::ILLEGAL, "0o"},
-            {TokenType::END, ""},
-        });
+TEST_CASE("Lexing illegal floats") {
+    helpers::test_lexer(".0 1..2 3.4.5 3.4u 5f",
+                        {
+                            {TokenType::DOT, "."},
+                            {TokenType::INT_10, "0"},
+                            {TokenType::INT_10, "1"},
+                            {TokenType::DOT_DOT, ".."},
+                            {TokenType::INT_10, "2"},
+                            {TokenType::F64, "3.4"},
+                            {TokenType::DOT, "."},
+                            {TokenType::INT_10, "5"},
+                            {TokenType::F64, "3.4"},
+                            {TokenType::IDENT, "u"},
+                            {TokenType::F32, "5f"},
+                        });
+}
 
-        for (const auto& [expected_tt, expected_slice] : expecteds) {
-            const auto token = l.advance();
-            CHECK(expected_tt == token.type);
-            CHECK(expected_slice == token.slice);
-        }
-    }
+TEST_CASE("Lexing signed int variants") {
+    helpers::test_lexer("0b1010 0o17 0O17 42 0x2A 0X2A 0b 0x 0o",
+                        {
+                            {TokenType::INT_2, "0b1010"},
+                            {TokenType::INT_8, "0o17"},
+                            {TokenType::INT_8, "0O17"},
+                            {TokenType::INT_10, "42"},
+                            {TokenType::INT_16, "0x2A"},
+                            {TokenType::INT_16, "0X2A"},
+                            {TokenType::ILLEGAL, "0b"},
+                            {TokenType::ILLEGAL, "0x"},
+                            {TokenType::ILLEGAL, "0o"},
+                        });
+}
 
-    SECTION("Unsigned integer variants") {
-        Lexer l{"0b1010u 0b1010uz 0o17u 0o17uz 0O17u 42u 42UZ 0x2AU 0X2Au 123ufoo 0bu 0xu 0ou"};
-
-        const auto expecteds = std::to_array<ExpectedLexeme>({
+TEST_CASE("Lexing unsigned int variants") {
+    helpers::test_lexer(
+        "0b1010u 0b1010uz 0o17u 0o17uz 0O17u 42u 42UZ 0x2AU 0X2Au 123ufoo 0bu 0xu 0ou",
+        {
             {TokenType::UINT_2, "0b1010u"},
             {TokenType::UZINT_2, "0b1010uz"},
             {TokenType::UINT_8, "0o17u"},
@@ -205,211 +183,157 @@ TEST_CASE("Integer base variants") {
             {TokenType::IDENT, "u"},
             {TokenType::ILLEGAL, "0o"},
             {TokenType::IDENT, "u"},
-            {TokenType::END, ""},
         });
+}
 
-        for (const auto& [expected_tt, expected_slice] : expecteds) {
-            const auto token = l.advance();
-            CHECK(expected_tt == token.type);
-            CHECK(expected_slice == token.slice);
-        }
-    }
+TEST_CASE("Lexing int bit-width variants") {
+    helpers::test_lexer("2 2l 2z 2u 2ul 2uz",
+                        {
+                            {TokenType::INT_10, "2"},
+                            {TokenType::LINT_10, "2l"},
+                            {TokenType::ZINT_10, "2z"},
+                            {TokenType::UINT_10, "2u"},
+                            {TokenType::ULINT_10, "2ul"},
+                            {TokenType::UZINT_10, "2uz"},
+                        });
+}
 
-    SECTION("Different integer widths") {
-        Lexer l{"2 2l 2z 2u 2ul 2uz"};
+TEST_CASE("Lexing keywords") {
+    helpers::test_lexer("and or pub extern export packed volatile static "
+                        "i32 i64 isize u32 u64 usize f32 f64 u8 bool void type",
+                        {
+                            {TokenType::BOOLEAN_AND, "and"},   {TokenType::BOOLEAN_OR, "or"},
+                            {TokenType::PUBLIC, "pub"},        {TokenType::EXTERN, "extern"},
+                            {TokenType::EXPORT, "export"},     {TokenType::PACKED, "packed"},
+                            {TokenType::VOLATILE, "volatile"}, {TokenType::STATIC, "static"},
+                            {TokenType::I32_TYPE, "i32"},      {TokenType::I64_TYPE, "i64"},
+                            {TokenType::ISIZE_TYPE, "isize"},  {TokenType::U32_TYPE, "u32"},
+                            {TokenType::U64_TYPE, "u64"},      {TokenType::USIZE_TYPE, "usize"},
+                            {TokenType::F32_TYPE, "f32"},      {TokenType::F64_TYPE, "f64"},
+                            {TokenType::U8_TYPE, "u8"},        {TokenType::BOOL_TYPE, "bool"},
+                            {TokenType::VOID_TYPE, "void"},    {TokenType::TYPE_TYPE, "type"},
+                        });
+}
 
-        const auto expecteds = std::to_array<ExpectedLexeme>({
-            {TokenType::INT_10, "2"},
-            {TokenType::LINT_10, "2l"},
-            {TokenType::ZINT_10, "2z"},
-            {TokenType::UINT_10, "2u"},
-            {TokenType::ULINT_10, "2ul"},
-            {TokenType::UZINT_10, "2uz"},
+TEST_CASE("Lexing comments") {
+    helpers::test_lexer("const five := 5;\n"
+                        "var ten_10 := 10;\n\n"
+                        "// BOL\n"
+                        "var result := add(five, ten); // EOL\n"
+                        "var four_and_some := 4.2f;",
+                        {
+                            {TokenType::CONST, "const"},  {TokenType::IDENT, "five"},
+                            {TokenType::WALRUS, ":="},    {TokenType::INT_10, "5"},
+                            {TokenType::SEMICOLON, ";"},  {TokenType::VAR, "var"},
+                            {TokenType::IDENT, "ten_10"}, {TokenType::WALRUS, ":="},
+                            {TokenType::INT_10, "10"},    {TokenType::SEMICOLON, ";"},
+                            {TokenType::COMMENT, " BOL"}, {TokenType::VAR, "var"},
+                            {TokenType::IDENT, "result"}, {TokenType::WALRUS, ":="},
+                            {TokenType::IDENT, "add"},    {TokenType::LPAREN, "("},
+                            {TokenType::IDENT, "five"},   {TokenType::COMMA, ","},
+                            {TokenType::IDENT, "ten"},    {TokenType::RPAREN, ")"},
+                            {TokenType::SEMICOLON, ";"},  {TokenType::COMMENT, " EOL"},
+                            {TokenType::VAR, "var"},      {TokenType::IDENT, "four_and_some"},
+                            {TokenType::WALRUS, ":="},    {TokenType::F32, "4.2f"},
+                            {TokenType::SEMICOLON, ";"},
+                        });
+}
+
+TEST_CASE("Lexing character literals") {
+    helpers::test_lexer("if'e' else'\\'\nreturn'\\r' break'\\n'\n"
+                        "continue'\\0' for'\\'' while'\\\\' const''\n"
+                        "var'asd'",
+                        {
+                            {TokenType::IF, "if"},
+                            {TokenType::U8, "'e'"},
+                            {TokenType::ELSE, "else"},
+                            {TokenType::ILLEGAL, "'\\'"},
+                            {TokenType::RETURN, "return"},
+                            {TokenType::U8, "'\\r'"},
+                            {TokenType::BREAK, "break"},
+                            {TokenType::U8, "'\\n'"},
+                            {TokenType::CONTINUE, "continue"},
+                            {TokenType::U8, "'\\0'"},
+                            {TokenType::FOR, "for"},
+                            {TokenType::U8, "'\\''"},
+                            {TokenType::WHILE, "while"},
+                            {TokenType::U8, "'\\\\'"},
+                            {TokenType::CONST, "const"},
+                            {TokenType::ILLEGAL, "'"},
+                            {TokenType::ILLEGAL, "'"},
+                            {TokenType::VAR, "var"},
+                            {TokenType::ILLEGAL, "'asd'"},
+                        });
+}
+
+TEST_CASE("Lexing string literals") {
+    helpers::test_lexer(
+        R"("This is a string";const five := "Hello, World!";var ten: [:0]u8 = "Hello\n, World!\0";var one := "Hello, World!;)",
+        {
+            {TokenType::STRING, R"("This is a string")"},
+            {TokenType::SEMICOLON, ";"},
+            {TokenType::CONST, "const"},
+            {TokenType::IDENT, "five"},
+            {TokenType::WALRUS, ":="},
+            {TokenType::STRING, R"("Hello, World!")"},
+            {TokenType::SEMICOLON, ";"},
+            {TokenType::VAR, "var"},
+            {TokenType::IDENT, "ten"},
+            {TokenType::COLON, ":"},
+            {TokenType::LBRACKET, "["},
+            {TokenType::NULL_TERMINATED, ":0"},
+            {TokenType::RBRACKET, "]"},
+            {TokenType::U8_TYPE, "u8"},
+            {TokenType::ASSIGN, "="},
+            {TokenType::STRING, R"("Hello\n, World!\0")"},
+            {TokenType::SEMICOLON, ";"},
+            {TokenType::VAR, "var"},
+            {TokenType::IDENT, "one"},
+            {TokenType::WALRUS, ":="},
+            {TokenType::ILLEGAL, R"("Hello, World!;)"},
         });
-
-        for (const auto& [expected_tt, expected_slice] : expecteds) {
-            const auto token = l.advance();
-            CHECK(expected_tt == token.type);
-            CHECK(expected_slice == token.slice);
-        }
-    }
 }
 
-TEST_CASE("Iterator with other keywords") {
-    Lexer l{"and or pub extern export packed volatile static "
-            "i32 i64 isize u32 u64 usize f32 f64 u8 bool void type"};
-
-    const auto expecteds = std::to_array<ExpectedLexeme>({
-        {TokenType::BOOLEAN_AND, "and"},   {TokenType::BOOLEAN_OR, "or"},
-        {TokenType::PUBLIC, "pub"},        {TokenType::EXTERN, "extern"},
-        {TokenType::EXPORT, "export"},     {TokenType::PACKED, "packed"},
-        {TokenType::VOLATILE, "volatile"}, {TokenType::STATIC, "static"},
-        {TokenType::I32_TYPE, "i32"},      {TokenType::I64_TYPE, "i64"},
-        {TokenType::ISIZE_TYPE, "isize"},  {TokenType::U32_TYPE, "u32"},
-        {TokenType::U64_TYPE, "u64"},      {TokenType::USIZE_TYPE, "usize"},
-        {TokenType::F32_TYPE, "f32"},      {TokenType::F64_TYPE, "f64"},
-        {TokenType::U8_TYPE, "u8"},        {TokenType::BOOL_TYPE, "bool"},
-        {TokenType::VOID_TYPE, "void"},    {TokenType::TYPE_TYPE, "type"},
-    });
-
-    size_t i = 0;
-    for (const auto& token : l) {
-        CHECK(expecteds[i].first == token.type);
-        CHECK(expecteds[i].second == token.slice);
-        i += 1;
-    }
+TEST_CASE("Lexing multiline string literals") {
+    helpers::test_lexer("const five := \\\\Multiline stringing\n"
+                        ";\n"
+                        "var ten := \\\\Multiline stringing\n"
+                        "\\\\Continuation\n"
+                        ";\n"
+                        "const one := \\\\Nesting \" \' \\ [] const var\n"
+                        "\\\\\n"
+                        ";\n",
+                        {
+                            {TokenType::CONST, "const"},
+                            {TokenType::IDENT, "five"},
+                            {TokenType::WALRUS, ":="},
+                            {TokenType::MULTILINE_STRING, "Multiline stringing"},
+                            {TokenType::SEMICOLON, ";"},
+                            {TokenType::VAR, "var"},
+                            {TokenType::IDENT, "ten"},
+                            {TokenType::WALRUS, ":="},
+                            {TokenType::MULTILINE_STRING, "Multiline stringing\n\\\\Continuation"},
+                            {TokenType::SEMICOLON, ";"},
+                            {TokenType::CONST, "const"},
+                            {TokenType::IDENT, "one"},
+                            {TokenType::WALRUS, ":="},
+                            {TokenType::MULTILINE_STRING, "Nesting \" \' \\ [] const var\n\\\\"},
+                            {TokenType::SEMICOLON, ";"},
+                        });
 }
 
-TEST_CASE("Comments") {
-    Lexer l{"const five := 5;\n"
-            "var ten_10 := 10;\n\n"
-            "// BOL\n"
-            "var add := fn(x, y) {\n"
-            "   x + y;\n"
-            "};\n\n"
-            "var result := add(five, ten); // EOL\n"
-            "var four_and_some := 4.2f;"};
-
-    const auto expecteds = std::to_array<ExpectedLexeme>({
-        {TokenType::CONST, "const"},  {TokenType::IDENT, "five"},
-        {TokenType::WALRUS, ":="},    {TokenType::INT_10, "5"},
-        {TokenType::SEMICOLON, ";"},  {TokenType::VAR, "var"},
-        {TokenType::IDENT, "ten_10"}, {TokenType::WALRUS, ":="},
-        {TokenType::INT_10, "10"},    {TokenType::SEMICOLON, ";"},
-        {TokenType::COMMENT, " BOL"}, {TokenType::VAR, "var"},
-        {TokenType::IDENT, "add"},    {TokenType::WALRUS, ":="},
-        {TokenType::FUNCTION, "fn"},  {TokenType::LPAREN, "("},
-        {TokenType::IDENT, "x"},      {TokenType::COMMA, ","},
-        {TokenType::IDENT, "y"},      {TokenType::RPAREN, ")"},
-        {TokenType::LBRACE, "{"},     {TokenType::IDENT, "x"},
-        {TokenType::PLUS, "+"},       {TokenType::IDENT, "y"},
-        {TokenType::SEMICOLON, ";"},  {TokenType::RBRACE, "}"},
-        {TokenType::SEMICOLON, ";"},  {TokenType::VAR, "var"},
-        {TokenType::IDENT, "result"}, {TokenType::WALRUS, ":="},
-        {TokenType::IDENT, "add"},    {TokenType::LPAREN, "("},
-        {TokenType::IDENT, "five"},   {TokenType::COMMA, ","},
-        {TokenType::IDENT, "ten"},    {TokenType::RPAREN, ")"},
-        {TokenType::SEMICOLON, ";"},  {TokenType::COMMENT, " EOL"},
-        {TokenType::VAR, "var"},      {TokenType::IDENT, "four_and_some"},
-        {TokenType::WALRUS, ":="},    {TokenType::F32, "4.2f"},
-        {TokenType::SEMICOLON, ";"},  {TokenType::END, ""},
-    });
-
-    for (const auto& [expected_tt, expected_slice] : expecteds) {
-        const auto token = l.advance();
-        CHECK(expected_tt == token.type);
-        CHECK(expected_slice == token.slice);
-    }
+TEST_CASE("Lexing pointers and references") {
+    helpers::test_lexer("& &mut * *mut nullptr",
+                        {
+                            {TokenType::BW_AND, "&"},
+                            {TokenType::AND_MUT, "&mut"},
+                            {TokenType::STAR, "*"},
+                            {TokenType::STAR_MUT, "*mut"},
+                            {TokenType::NULLPTR, "nullptr"},
+                        });
 }
 
-TEST_CASE("Character literals") {
-    Lexer l{"if'e' else'\\'\nreturn'\\r' break'\\n'\n"
-            "continue'\\0' for'\\'' while'\\\\' const''\n"
-            "var'asd'"};
-
-    const auto expecteds = std::to_array<ExpectedLexeme>({
-        {TokenType::IF, "if"},
-        {TokenType::U8, "'e'"},
-        {TokenType::ELSE, "else"},
-        {TokenType::ILLEGAL, "'\\'"},
-        {TokenType::RETURN, "return"},
-        {TokenType::U8, "'\\r'"},
-        {TokenType::BREAK, "break"},
-        {TokenType::U8, "'\\n'"},
-        {TokenType::CONTINUE, "continue"},
-        {TokenType::U8, "'\\0'"},
-        {TokenType::FOR, "for"},
-        {TokenType::U8, "'\\''"},
-        {TokenType::WHILE, "while"},
-        {TokenType::U8, "'\\\\'"},
-        {TokenType::CONST, "const"},
-        {TokenType::ILLEGAL, "'"},
-        {TokenType::ILLEGAL, "'"},
-        {TokenType::VAR, "var"},
-        {TokenType::ILLEGAL, "'asd'"},
-        {TokenType::END, ""},
-    });
-
-    for (const auto& [expected_tt, expected_slice] : expecteds) {
-        const auto token = l.advance();
-        CHECK(expected_tt == token.type);
-        CHECK(expected_slice == token.slice);
-    }
-}
-
-TEST_CASE("String literals") {
-    Lexer l{
-        R"("This is a string";const five := "Hello, World!";var ten: [:0]u8 = "Hello\n, World!\0";var one := "Hello, World!;)"};
-
-    const auto expecteds = std::to_array<ExpectedLexeme>({
-        {TokenType::STRING, R"("This is a string")"},
-        {TokenType::SEMICOLON, ";"},
-        {TokenType::CONST, "const"},
-        {TokenType::IDENT, "five"},
-        {TokenType::WALRUS, ":="},
-        {TokenType::STRING, R"("Hello, World!")"},
-        {TokenType::SEMICOLON, ";"},
-        {TokenType::VAR, "var"},
-        {TokenType::IDENT, "ten"},
-        {TokenType::COLON, ":"},
-        {TokenType::LBRACKET, "["},
-        {TokenType::NULL_TERMINATED, ":0"},
-        {TokenType::RBRACKET, "]"},
-        {TokenType::U8_TYPE, "u8"},
-        {TokenType::ASSIGN, "="},
-        {TokenType::STRING, R"("Hello\n, World!\0")"},
-        {TokenType::SEMICOLON, ";"},
-        {TokenType::VAR, "var"},
-        {TokenType::IDENT, "one"},
-        {TokenType::WALRUS, ":="},
-        {TokenType::ILLEGAL, R"("Hello, World!;)"},
-        {TokenType::END, ""},
-    });
-
-    for (const auto& [expected_tt, expected_slice] : expecteds) {
-        const auto token = l.advance();
-        CHECK(expected_tt == token.type);
-        CHECK(expected_slice == token.slice);
-    }
-}
-
-TEST_CASE("Multiline string literals") {
-    Lexer l{"const five := \\\\Multiline stringing\n"
-            ";\n"
-            "var ten := \\\\Multiline stringing\n"
-            "\\\\Continuation\n"
-            ";\n"
-            "const one := \\\\Nesting \" \' \\ [] const var\n"
-            "\\\\\n"
-            ";\n"};
-
-    const auto expecteds = std::to_array<ExpectedLexeme>({
-        {TokenType::CONST, "const"},
-        {TokenType::IDENT, "five"},
-        {TokenType::WALRUS, ":="},
-        {TokenType::MULTILINE_STRING, "Multiline stringing"},
-        {TokenType::SEMICOLON, ";"},
-        {TokenType::VAR, "var"},
-        {TokenType::IDENT, "ten"},
-        {TokenType::WALRUS, ":="},
-        {TokenType::MULTILINE_STRING, "Multiline stringing\n\\\\Continuation"},
-        {TokenType::SEMICOLON, ";"},
-        {TokenType::CONST, "const"},
-        {TokenType::IDENT, "one"},
-        {TokenType::WALRUS, ":="},
-        {TokenType::MULTILINE_STRING, "Nesting \" \' \\ [] const var\n\\\\"},
-        {TokenType::SEMICOLON, ";"},
-        {TokenType::END, ""},
-    });
-
-    for (const auto& [expected_tt, expected_slice] : expecteds) {
-        const auto token = l.advance();
-        CHECK(expected_tt == token.type);
-        CHECK(expected_slice == token.slice);
-    }
-}
-
-TEST_CASE("Compiler builtins") {
+TEST_CASE("Lexing compiler builtins & Lexer resetting") {
     const auto expecteds =
         std::ranges::views::transform(ALL_BUILTINS, [](const auto& builtin) -> ExpectedLexeme {
             return {builtin.second, builtin.first};
@@ -422,34 +346,27 @@ TEST_CASE("Compiler builtins") {
     });
     Lexer l{input};
 
+    Lexer      l_accumulator{input};
+    const auto accumulated_tokens = l_accumulator.consume();
+    l_accumulator.reset(input);
+    const auto reset_acc = l_accumulator.consume();
+
+    usize i = 0;
     for (const auto& [expected_tt, expected_slice] : expecteds) {
-        const auto token = l.advance();
+        const auto  token             = l.advance();
+        const auto& accumulated_token = accumulated_tokens[i];
+        const auto& reset             = reset_acc[i];
+
         CHECK(expected_tt == token.type);
+        CHECK(expected_tt == accumulated_token.type);
         CHECK(expected_slice == token.slice);
-        CHECK(is_builtin(token.type));
-    }
-}
-
-TEST_CASE("Pointers and references") {
-    Lexer l{"& &mut * *mut nullptr"};
-
-    const auto expecteds = std::to_array<ExpectedLexeme>({
-        {TokenType::BW_AND, "&"},
-        {TokenType::AND_MUT, "&mut"},
-        {TokenType::STAR, "*"},
-        {TokenType::STAR_MUT, "*mut"},
-        {TokenType::NULLPTR, "nullptr"},
-    });
-
-    size_t i = 0;
-    for (const auto& token : l) {
-        CHECK(expecteds[i].first == token.type);
-        CHECK(expecteds[i].second == token.slice);
+        CHECK(expected_slice == accumulated_token.slice);
+        CHECK(accumulated_token == reset);
         i += 1;
     }
 }
 
-TEST_CASE("Illegal builtins") {
+TEST_CASE("Lexing illegal builtin") {
     const std::string_view input{"@run"};
     Lexer                  l{input};
     const auto             illegal = l.advance();

--- a/lib/compiler/tests/syntax/test_token.cpp
+++ b/lib/compiler/tests/syntax/test_token.cpp
@@ -1,102 +1,67 @@
-#include <string>
-
 #include <fmt/format.h>
 
 #include <catch2/catch_test_macros.hpp>
 
 #include "syntax/token.hpp"
 
+#include "variant.hpp"
+
 namespace porpoise::tests {
 
 using namespace syntax;
 
-TEST_CASE("Promotion of invalid tokens") {
-    const auto  input{"1"};
-    const Token tok{TokenType::INT_10, input, 0, 0};
+namespace helpers {
 
-    const auto promoted = tok.promote();
-    CHECK_FALSE(promoted);
-    CHECK(promoted.error() == Diagnostic{TokenError::NON_STRING_TOKEN, 0, 0});
+auto test_token_promotion(std::string_view                           input,
+                          TokenType                                  type,
+                          std::variant<std::string_view, TokenError> expected) -> void {
+    const Token tok{type, input, 0, 0};
+    const auto  promoted = tok.promote();
+
+    std::visit(Overloaded{[&promoted](const std::string_view& string) {
+                              CHECK(promoted);
+                              CHECK(*promoted == string);
+                          },
+                          [&promoted](const TokenError& error) {
+                              CHECK_FALSE(promoted);
+                              CHECK(promoted.error() == TokenDiagnostic{error, 0, 0});
+                          }},
+               expected);
+}
+
+auto test_string(std::string_view input, std::variant<std::string_view, TokenError> expected) {
+    test_token_promotion(input, TokenType::STRING, expected);
+}
+
+auto test_ml_string(std::string_view input, std::variant<std::string_view, TokenError> expected) {
+    test_token_promotion(input, TokenType::MULTILINE_STRING, expected);
+}
+
+} // namespace helpers
+
+TEST_CASE("Promotion of invalid tokens") {
+    helpers::test_token_promotion("1", TokenType::INT_10, TokenError::NON_STRING_TOKEN);
 }
 
 TEST_CASE("Promotion of standard string literals") {
-    SECTION("Normal case") {
-        const auto  input{R"("Hello, World!")"};
-        const Token tok = {TokenType::STRING, input, 0, 0};
+    helpers::test_string(R"("Hello, World!")", "Hello, World!");
+    helpers::test_string(R"(""Hello, World!"")", R"("Hello, World!")");
+    helpers::test_string(R"("")", "");
+}
 
-        const auto promoted = tok.promote();
-        CHECK(promoted);
-        const auto expected{"Hello, World!"};
-        CHECK(expected == *promoted);
-    }
-
-    SECTION("Escaped case") {
-        const auto  input{R"(""Hello, World!"")"};
-        const Token tok{TokenType::STRING, input, 0, 0};
-
-        const auto promoted = tok.promote();
-        CHECK(promoted);
-        const auto expected{R"("Hello, World!")"};
-        CHECK(expected == *promoted);
-    }
-
-    SECTION("Empty case") {
-        const auto  input{R"("")"};
-        const Token tok{TokenType::STRING, input, 0, 0};
-
-        const auto promoted = tok.promote();
-        CHECK(promoted);
-        const std::string expected;
-        CHECK(expected == *promoted);
-    }
-
-    SECTION("Malformed case") {
-        const auto  input{R"(")"};
-        const Token tok{TokenType::STRING, input, 0, 0};
-
-        const auto promoted = tok.promote();
-        CHECK_FALSE(promoted);
-        CHECK(promoted.error() == Diagnostic{TokenError::UNEXPECTED_CHAR, 0, 0});
-    }
+TEST_CASE("Malformed string literal") {
+    helpers::test_token_promotion(R"(")", TokenType::STRING, TokenError::UNEXPECTED_CHAR);
 }
 
 TEST_CASE("Promotion of multiline literals") {
-    SECTION("Normal case no newline") {
-        const auto  input{R"(\\Hello,"World!")"};
-        const Token tok{TokenType::MULTILINE_STRING, input, 0, 0};
-
-        const auto promoted = tok.promote();
-        CHECK(promoted);
-        const auto expected = R"(Hello,"World!")";
-        CHECK(expected == *promoted);
-    }
-
-    SECTION("Normal case newline") {
-        const auto  input{"\\\\Hello,\n\\\\World!\n\\\\"};
-        const Token tok{TokenType::MULTILINE_STRING, input, 0, 0};
-
-        const auto promoted = tok.promote();
-        CHECK(promoted);
-        const auto expected = "Hello,\nWorld!\n";
-        CHECK(expected == *promoted);
-    }
-
-    SECTION("Empty case") {
-        const auto  input{R"(\\)"};
-        const Token tok{TokenType::MULTILINE_STRING, input, 0, 0};
-
-        const auto promoted = tok.promote();
-        CHECK(promoted);
-        const std::string expected;
-        CHECK(expected == *promoted);
-    }
+    helpers::test_ml_string(R"(\\Hello,"World!")", R"(Hello,"World!")");
+    helpers::test_ml_string("\\\\Hello,\n\\\\World!\n\\\\", "Hello,\nWorld!\n");
+    helpers::test_ml_string(R"(\\)", "");
 }
 
 TEST_CASE("Token formatting") {
-    const Token tok{TokenType::STRING, R"("Hello, World!")", 1, 24};
-
     const auto expected{R"(STRING("Hello, World!") [1, 24])"};
-    const auto actual = fmt::format("{}", tok);
+    const auto actual = fmt::format("{}", Token{TokenType::STRING, R"("Hello, World!")", 1, 24});
     CHECK(expected == actual);
 }
 


### PR DESCRIPTION
## Description

Closes #91

## Additional Context:

Adjusts the compiler's syntax tests to match the quality of the rest of the test suite by reducing loads of code duplication.
