### PR TITLE
Add Test Statements to the Top Level

### DIFF
--- a/lib/compiler/include/ast/ast.hpp
+++ b/lib/compiler/include/ast/ast.hpp
@@ -35,6 +35,7 @@
 #include "ast/statements/import.hpp"
 #include "ast/statements/jump.hpp"
 #include "ast/statements/module.hpp"
+#include "ast/statements/test.hpp"
 #include "ast/statements/using.hpp"
 
 // IWYU pragma: end_exports

--- a/lib/compiler/include/ast/node.hpp
+++ b/lib/compiler/include/ast/node.hpp
@@ -70,6 +70,7 @@ enum class NodeKind : u8 {
     IMPORT_STATEMENT,
     JUMP_STATEMENT,
     MODULE_STATEMENT,
+    TEST_STATEMENT,
     USING_STATEMENT,
 };
 

--- a/lib/compiler/include/ast/statements/block.hpp
+++ b/lib/compiler/include/ast/statements/block.hpp
@@ -25,7 +25,7 @@ class BlockStatement : public StmtBase<BlockStatement> {
     MAKE_MOVE_CONSTRUCTABLE_ONLY(BlockStatement)
 
     auto                      accept(Visitor& v) const -> void override;
-    [[nodiscard]] static auto parse(syntax::Parser& parser)
+    [[nodiscard]] static auto parse(syntax::Parser& parser, bool allow_imports = false)
         -> Expected<mem::Box<Statement>, syntax::ParserDiagnostic>;
 
   protected:

--- a/lib/compiler/include/ast/statements/test.hpp
+++ b/lib/compiler/include/ast/statements/test.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "ast/node.hpp"
+
+#include "syntax/parser.hpp"
+
+namespace porpoise::ast {
+
+class StringExpression;
+class BlockStatement;
+
+class TestStatement : public StmtBase<TestStatement> {
+  public:
+    static constexpr auto KIND = NodeKind::TEST_STATEMENT;
+
+  public:
+    TestStatement(const syntax::Token&                 start_token,
+                  Optional<mem::Box<StringExpression>> description,
+                  mem::Box<BlockStatement>             block) noexcept;
+    ~TestStatement() override;
+
+    MAKE_MOVE_CONSTRUCTABLE_ONLY(TestStatement)
+
+    auto                      accept(Visitor& v) const -> void override;
+    [[nodiscard]] static auto parse(syntax::Parser& parser)
+        -> Expected<mem::Box<Statement>, syntax::ParserDiagnostic>;
+
+    MAKE_OPTIONAL_UNPACKER(description, StringExpression, description_, **)
+    MAKE_GETTER(block, const BlockStatement&, *)
+
+  protected:
+    auto is_equal(const Node& other) const noexcept -> bool override;
+
+  private:
+    Optional<mem::Box<StringExpression>> description_;
+    mem::Box<BlockStatement>             block_;
+};
+
+} // namespace porpoise::ast

--- a/lib/compiler/include/ast/visitor.hpp
+++ b/lib/compiler/include/ast/visitor.hpp
@@ -59,6 +59,7 @@ namespace porpoise::ast {
     X(ImportStatement)      \
     X(JumpStatement)        \
     X(ModuleStatement)      \
+    X(TestStatement)        \
     X(UsingStatement)
 
 #define FOREACH_AST_NODE(X) \

--- a/lib/compiler/include/sema/error.hpp
+++ b/lib/compiler/include/sema/error.hpp
@@ -19,6 +19,7 @@ enum class Error : u8 {
     INVALID_TABLE_IDX,
     SHADOWING_DECLARATION,
     CIRCULAR_DEPENDENCY,
+    ILLEGAL_TEST_LOCATION,
 };
 
 using Diagnostic  = Diagnostic<Error>;

--- a/lib/compiler/include/sema/type.hpp
+++ b/lib/compiler/include/sema/type.hpp
@@ -36,6 +36,7 @@ enum class TypeKind : u8 {
     STRUCT,
     UNION,
     FUNCTION,
+    TEST_BLOCK,
 };
 
 class Type;

--- a/lib/compiler/include/syntax/keywords.hpp
+++ b/lib/compiler/include/syntax/keywords.hpp
@@ -59,6 +59,7 @@ constexpr Keyword NORETURN{"noreturn", TokenType::NORETURN};
 constexpr Keyword NULLPTR{"nullptr", TokenType::NULLPTR};
 constexpr Keyword USING{"using", TokenType::USING};
 constexpr Keyword MODULE{"module", TokenType::MODULE};
+constexpr Keyword TEST{"test", TokenType::TEST};
 
 namespace builtins {
 
@@ -110,6 +111,7 @@ constexpr auto ALL_KEYWORDS = [] {
         keywords::TYPE,     keywords::AS,      keywords::PUBLIC,   keywords::EXTERN,
         keywords::EXPORT,   keywords::PACKED,  keywords::VOLATILE, keywords::STATIC,
         keywords::NORETURN, keywords::NULLPTR, keywords::USING,    keywords::MODULE,
+        keywords::TEST,
     };
 
     std::ranges::sort(all_keywords, {}, &Keyword::first);

--- a/lib/compiler/include/syntax/parser.hpp
+++ b/lib/compiler/include/syntax/parser.hpp
@@ -80,6 +80,7 @@ enum class ParserError : u8 {
     EMPTY_ENUM,
     ILLEGAL_DEFERRED_STATEMENT,
     DEFER_MISSING_DEFERREE,
+    EMPTY_TEST_DESCRIPTION,
 };
 
 using ParserDiagnostic = Diagnostic<ParserError>;

--- a/lib/compiler/include/syntax/token.hpp
+++ b/lib/compiler/include/syntax/token.hpp
@@ -147,6 +147,7 @@ enum class TokenType : u8 {
     AS,
     DEFER,
     MODULE,
+    TEST,
 
     I32_TYPE,
     I64_TYPE,

--- a/lib/compiler/src/ast/dumper.cpp
+++ b/lib/compiler/src/ast/dumper.cpp
@@ -585,6 +585,8 @@ auto ASTDumper::visit(const JumpStatement& jump) -> void {
 
 auto ASTDumper::visit(const ModuleStatement&) -> void { fmt::println(out_, "ModuleStatement"); }
 
+auto ASTDumper::visit(const TestStatement& test) -> void { TODO(test); }
+
 auto ASTDumper::visit(const UsingStatement& using_stmt) -> void {
     fmt::println(out_, "UsingStatement");
     {

--- a/lib/compiler/src/ast/dumper.cpp
+++ b/lib/compiler/src/ast/dumper.cpp
@@ -585,7 +585,19 @@ auto ASTDumper::visit(const JumpStatement& jump) -> void {
 
 auto ASTDumper::visit(const ModuleStatement&) -> void { fmt::println(out_, "ModuleStatement"); }
 
-auto ASTDumper::visit(const TestStatement& test) -> void { TODO(test); }
+auto ASTDumper::visit(const TestStatement& test) -> void {
+    fmt::println(out_, "TestStatement");
+    if (test.has_description()) {
+        const Indent::Guard g{indent_, false};
+        fmt::println(out_, "{}Description: {}", indent_.current_branch(), test.get_description());
+    }
+
+    {
+        const Indent::Guard g{indent_, true};
+        fmt::print(out_, "{}Block: ", indent_.current_branch());
+        test.get_block().accept(*this);
+    }
+}
 
 auto ASTDumper::visit(const UsingStatement& using_stmt) -> void {
     fmt::println(out_, "UsingStatement");

--- a/lib/compiler/src/ast/statements/block.cpp
+++ b/lib/compiler/src/ast/statements/block.cpp
@@ -7,7 +7,7 @@ namespace porpoise::ast {
 
 auto BlockStatement::accept(Visitor& v) const -> void { v.visit(*this); }
 
-auto BlockStatement::parse(syntax::Parser& parser)
+auto BlockStatement::parse(syntax::Parser& parser, bool allow_imports)
     -> Expected<mem::Box<Statement>, syntax::ParserDiagnostic> {
     const auto start_token = parser.current_token();
 
@@ -17,8 +17,8 @@ auto BlockStatement::parse(syntax::Parser& parser)
         parser.advance();
         auto inner_stmt = TRY(parser.parse_statement());
 
-        // Import statements are only allowed at the top level
-        if (inner_stmt->is<ImportStatement>()) {
+        // Import statements are usually only allowed at the top level
+        if (!allow_imports && inner_stmt->is<ImportStatement>()) {
             return make_parser_unexpected(syntax::ParserError::ILLEGAL_BLOCK_STATEMENT,
                                           inner_stmt->get_token());
         }

--- a/lib/compiler/src/ast/statements/test.cpp
+++ b/lib/compiler/src/ast/statements/test.cpp
@@ -1,0 +1,38 @@
+#include "ast/statements/test.hpp"
+
+#include "ast/expressions/primitive.hpp"
+#include "ast/statements/block.hpp"
+#include "ast/visitor.hpp"
+
+namespace porpoise::ast {
+
+TestStatement::TestStatement(const syntax::Token&                 start_token,
+                             Optional<mem::Box<StringExpression>> description,
+                             mem::Box<BlockStatement>             block) noexcept
+    : StmtBase{start_token}, description_{std::move(description)}, block_{std::move(block)} {}
+TestStatement::~TestStatement() = default;
+
+auto TestStatement::accept(Visitor& v) const -> void { v.visit(*this); }
+
+auto TestStatement::parse(syntax::Parser& parser)
+    -> Expected<mem::Box<Statement>, syntax::ParserDiagnostic> {
+    const auto start_token = parser.current_token();
+
+    Optional<mem::Box<StringExpression>> description;
+    if (parser.peek_token_is(syntax::TokenType::STRING)) {
+        parser.advance();
+        description.emplace(downcast<StringExpression>(TRY(StringExpression::parse(parser))));
+    }
+
+    TRY(parser.expect_peek(syntax::TokenType::LBRACE));
+    auto block = downcast<BlockStatement>(TRY(BlockStatement::parse(parser)));
+    return mem::make_box<TestStatement>(start_token, std::move(description), std::move(block));
+}
+
+auto TestStatement::is_equal(const Node& other) const noexcept -> bool {
+    const auto& casted = as<TestStatement>(other);
+    return optional::unsafe_eq<StringExpression>(description_, casted.description_) &&
+           *block_ == *casted.block_;
+}
+
+} // namespace porpoise::ast

--- a/lib/compiler/src/ast/statements/test.cpp
+++ b/lib/compiler/src/ast/statements/test.cpp
@@ -22,11 +22,19 @@ auto TestStatement::parse(syntax::Parser& parser)
     if (parser.peek_token_is(syntax::TokenType::STRING)) {
         parser.advance();
         description.emplace(downcast<StringExpression>(TRY(StringExpression::parse(parser))));
+
+        // Empty strings aren't supported since one should just use no description
+        if ((*description)->get_value().empty()) {
+            return make_parser_unexpected(syntax::ParserError::EMPTY_TEST_DESCRIPTION,
+                                          (*description)->get_token());
+        }
     }
 
     TRY(parser.expect_peek(syntax::TokenType::LBRACE));
-    auto block = downcast<BlockStatement>(TRY(BlockStatement::parse(parser)));
-    return mem::make_box<TestStatement>(start_token, std::move(description), std::move(block));
+    return mem::make_box<TestStatement>(
+        start_token,
+        std::move(description),
+        downcast<BlockStatement>(TRY(BlockStatement::parse(parser, true))));
 }
 
 auto TestStatement::is_equal(const Node& other) const noexcept -> bool {

--- a/lib/compiler/src/sema/symbol_collector.cpp
+++ b/lib/compiler/src/sema/symbol_collector.cpp
@@ -212,6 +212,8 @@ auto SymbolCollector::visit(const ast::ModuleStatement& module_stmt) -> void {
     }
 }
 
+auto SymbolCollector::visit(const ast::TestStatement& test) -> void { TODO(test); }
+
 auto SymbolCollector::visit(const ast::UsingStatement& using_stmt) -> void {
     if (registry_.get(table_idx_).is_module()) { using_stmt.mark_public(); }
     try_declare(using_stmt.get_alias().get_name(), &using_stmt);

--- a/lib/compiler/src/sema/symbol_collector.cpp
+++ b/lib/compiler/src/sema/symbol_collector.cpp
@@ -183,7 +183,6 @@ ILLEGAL_COLLECTOR_TOP_LEVEL(ast::DiscardStatement, "discard")
 ILLEGAL_COLLECTOR_TOP_LEVEL(ast::ExpressionStatement, "expression")
 
 auto SymbolCollector::visit(const ast::ImportStatement& import_stmt) -> void {
-    assert(table_stack_.size() == 1 && "Import not at top level");
     if (registry_.get(table_idx_).is_module()) { import_stmt.mark_public(); }
     const auto name = import_stmt.match(Overloaded{
         [](const ast::LibraryImport& module) {
@@ -212,7 +211,20 @@ auto SymbolCollector::visit(const ast::ModuleStatement& module_stmt) -> void {
     }
 }
 
-auto SymbolCollector::visit(const ast::TestStatement& test) -> void { TODO(test); }
+auto SymbolCollector::visit(const ast::TestStatement& test) -> void {
+    if (table_idx_ != 0) {
+        diagnostics_.emplace_back("Tests must be at the topmost level of a file",
+                                  Error::ILLEGAL_TEST_LOCATION,
+                                  test.get_token());
+        return;
+    }
+
+    // Not a symbol so don't push to the table, track in node instead
+    const auto scope_idx = visit_scope(
+        test.get_block(), TypeKind::TEST_BLOCK, [this](const auto& decl) { decl->accept(*this); });
+    last_type_->set_symbol_table(scope_idx);
+    test.set_sema_type(*last_type_.take());
+}
 
 auto SymbolCollector::visit(const ast::UsingStatement& using_stmt) -> void {
     if (registry_.get(table_idx_).is_module()) { using_stmt.mark_public(); }

--- a/lib/compiler/src/sema/type_resolver.cpp
+++ b/lib/compiler/src/sema/type_resolver.cpp
@@ -110,6 +110,8 @@ auto TypeResolver::visit(const ast::JumpStatement&) -> void {}
 
 auto TypeResolver::visit(const ast::ModuleStatement&) -> void {}
 
+auto TypeResolver::visit(const ast::TestStatement&) -> void {}
+
 auto TypeResolver::visit(const ast::UsingStatement&) -> void {}
 
 } // namespace porpoise::sema

--- a/lib/compiler/src/syntax/parser.cpp
+++ b/lib/compiler/src/syntax/parser.cpp
@@ -107,6 +107,7 @@ auto Parser::parse_statement() -> Expected<mem::Box<ast::Statement>, ParserDiagn
     case TokenType::UNDERSCORE: return ast::DiscardStatement::parse(*this);
     case TokenType::MODULE:     return ast::ModuleStatement::parse(*this);
     case TokenType::USING:      return ast::UsingStatement::parse(*this);
+    case TokenType::TEST:       return ast::TestStatement::parse(*this);
     default:                    return ast::ExpressionStatement::parse(*this);
     }
 }

--- a/lib/compiler/tests/ast/dump.inc
+++ b/lib/compiler/tests/ast/dump.inc
@@ -386,4 +386,20 @@ DeclStatement (a)
 ├─ Modifiers: CONSTANT
 ├─ Type: (inferred)
 └─ Value: VoidExpression
+TestStatement
+├─ Description: dump
+└─ Block: BlockStatement
+    ├─ ImportStatement
+    │   └─ Library: IdentifierExpression: other
+    └─ ExpressionStatement
+        └─ Expr: CallExpression
+            ├─ Callee: ScopeResolutionExpression
+            │   ├─ Outer: ScopeResolutionExpression
+            │   │   ├─ Outer: IdentifierExpression: std
+            │   │   └─ Inner: IdentifierExpression: testing
+            │   └─ Inner: IdentifierExpression: expect
+            └─ Arguments:
+                └─ BinaryExpression (EQ)
+                    ├─ LHS: IdentifierExpression: a
+                    └─ RHS: BoolExpression: true
 )"

--- a/lib/compiler/tests/ast/statements/test_test.cpp
+++ b/lib/compiler/tests/ast/statements/test_test.cpp
@@ -1,0 +1,55 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "helpers/ast.hpp"
+
+namespace porpoise::tests {
+
+namespace keywords = syntax::keywords;
+
+TEST_CASE("Well formed test statement") {
+    helpers::test_stmt(
+        R"(test "good" { a; b; c; })",
+        ast::TestStatement{syntax::Token{keywords::TEST},
+                           helpers::make_primitive<ast::StringExpression>(R"("good")"),
+                           helpers::make_expr_block_stmt(helpers::ident_from("a"),
+                                                         helpers::ident_from("b"),
+                                                         helpers::ident_from("c"))});
+}
+
+TEST_CASE("Forwarding test") {
+    helpers::test_stmt(
+        "test { import other; };",
+        ast::TestStatement{syntax::Token{keywords::TEST},
+                           std::nullopt,
+                           helpers::make_block_stmt(ast::ImportStatement{
+                               syntax::Token{keywords::IMPORT},
+                               ast::LibraryImport{helpers::make_ident("other"), {}}})});
+}
+
+TEST_CASE("Empty test") {
+    helpers::test_stmt("test {};",
+                       ast::TestStatement{syntax::Token{keywords::TEST},
+                                          std::nullopt,
+                                          helpers::make_block_stmt()});
+
+    helpers::test_stmt(
+        R"(test "something" {})",
+        ast::TestStatement{syntax::Token{keywords::TEST},
+                           helpers::make_primitive<ast::StringExpression>(R"("something")"),
+                           helpers::make_block_stmt()});
+}
+
+TEST_CASE("Non-terminated test") {
+    helpers::test_parser_fail(
+        "test {",
+        syntax::ParserDiagnostic{
+            "Expected token RBRACE, found END", syntax::ParserError::UNEXPECTED_TOKEN, 1, 7});
+}
+
+TEST_CASE("Empty test description") {
+    helpers::test_parser_fail(
+        R"(test "" {};)",
+        syntax::ParserDiagnostic{syntax::ParserError::EMPTY_TEST_DESCRIPTION, 1, 6});
+}
+
+} // namespace porpoise::tests

--- a/lib/compiler/tests/ast/test_dumper.cpp
+++ b/lib/compiler/tests/ast/test_dumper.cpp
@@ -53,6 +53,7 @@ constexpr std::string_view input{R"(
     union { a: *struct { var b: Foo = bar; }, const b := fn(&self, a: A): C { c; }; };
     enum : i64 { A = 2l, const b := fn(&self, a: A): C { c; }; };
     const a := {};
+    test "dump" { import other; std::testing::expect(a == true); }
 )"};
 
 constexpr std::string_view expected{

--- a/lib/compiler/tests/sema/test_symbol_collector.cpp
+++ b/lib/compiler/tests/sema/test_symbol_collector.cpp
@@ -436,4 +436,19 @@ TEST_CASE("Function block shadowing") {
                          std::pair{1uz, 25uz}});
 }
 
+TEST_CASE("Test shadowing") {
+    helpers::test_collector_fail(
+        R"(const a := 2; test "foo" { const a := 3; })",
+        sema::Diagnostic{"Attempt to shadow identifier 'a'. Previous declaration here: [1, 1]",
+                         sema::Error::SHADOWING_DECLARATION,
+                         std::pair{1uz, 28uz}});
+}
+
+TEST_CASE("Illegal test location") {
+    helpers::test_collector_fail("const a := fn(&self): void { test {} };",
+                                 sema::Diagnostic{"Tests must be at the topmost level of a file",
+                                                  sema::Error::ILLEGAL_TEST_LOCATION,
+                                                  std::pair{1uz, 30uz}});
+}
+
 } // namespace porpoise::tests

--- a/lib/compiler/tests/syntax/test_lexer.cpp
+++ b/lib/compiler/tests/syntax/test_lexer.cpp
@@ -199,7 +199,7 @@ TEST_CASE("Lexing int bit-width variants") {
 
 TEST_CASE("Lexing keywords") {
     helpers::test_lexer("and or pub extern export packed volatile static "
-                        "i32 i64 isize u32 u64 usize f32 f64 u8 bool void type",
+                        "i32 i64 isize u32 u64 usize f32 f64 u8 bool void type test",
                         {
                             {TokenType::BOOLEAN_AND, "and"},   {TokenType::BOOLEAN_OR, "or"},
                             {TokenType::PUBLIC, "pub"},        {TokenType::EXTERN, "extern"},
@@ -211,6 +211,7 @@ TEST_CASE("Lexing keywords") {
                             {TokenType::F32_TYPE, "f32"},      {TokenType::F64_TYPE, "f64"},
                             {TokenType::U8_TYPE, "u8"},        {TokenType::BOOL_TYPE, "bool"},
                             {TokenType::VOID_TYPE, "void"},    {TokenType::TYPE_TYPE, "type"},
+                            {TokenType::TEST, "test"},
                         });
 }
 


### PR DESCRIPTION
## Description

Closes #89 

## Additional Context:

Is a great step in the right direction for adding first class unit test support (#87). This PR integrates test statements into every current existing step in the compilation process (parsing and symbol collection), and introduces some optional flexibility for block statement parsing. 
