### PR TITLE
Add Go as a Dependency for Documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
         paths:
             - ".github/workflows/ci.yml"
             - "lib/**"
+            - "site/**"
             - "ghoti/main.cc"
             - "third-party/**"
             - "tools/harness/**"
@@ -37,6 +38,9 @@ jobs:
             - uses: mlugg/setup-zig@v2
               with:
                   version: 0.16.0
+            - uses: actions/setup-go@v5
+              with:
+                  go-version: "1.26.3"
 
             - name: Cache Zig Folders
               uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,8 @@ jobs:
               uses: nick-fields/retry@v3
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 4
+                  retry_wait_seconds: 30
                   command: zig build --fetch=all
 
             - name: Run tests (debug)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,7 +46,8 @@ jobs:
               uses: nick-fields/retry@v3
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 4
+                  retry_wait_seconds: 30
                   command: zig build --fetch=all
 
             - name: Run coverage reporter

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,7 @@ on:
         paths:
             - ".github/workflows/format.yml"
             - "lib/**"
+            - "site/**"
             - "ghoti/main.cc"
             - "third-party/**"
             - "tools/harness/**"
@@ -31,6 +32,9 @@ jobs:
             - uses: mlugg/setup-zig@v2
               with:
                   version: 0.16.0
+            - uses: actions/setup-go@v5
+              with:
+                  go-version: "1.26.3"
 
             - name: Cache Zig Folders
               uses: actions/cache@v4

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -50,7 +50,8 @@ jobs:
               uses: nick-fields/retry@v3
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 4
+                  retry_wait_seconds: 30
                   command: zig build --fetch=all
 
             - name: Check formatting

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -29,7 +29,8 @@ jobs:
               uses: nick-fields/retry@v3
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 4
+                  retry_wait_seconds: 30
                   command: zig build --fetch=all
 
             - name: Build and package

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,14 @@ zig-out/
 .zig-cache
 zig-pkg/
 
+# Go
+*.test
+go.work
+go.work.sum
+
+# Templ
+*_templ.go
+
 # Lsp caches
 .cache
 __cmake_systeminformation/
@@ -75,3 +83,4 @@ __cmake_systeminformation/
 # MISC
 .DS_Store
 debug.gh
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ zig-pkg/
 *.test
 go.work
 go.work.sum
+site/tmp
 
 # Templ
 *_templ.go

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@
 TMP_*
 
 # Kernel Module Compile Results
-*.mod*
 *.cmd
 .tmp_versions/
 modules.order

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 <p align="center">
 A hand-crafted systems programming language.
-<br />
+<br/>
 <a href="https://github.com/trevorswan11/ghoti/tree/main/doc"><strong>Explore the docs »</strong></a>
-<br />
-<br />
+<br/>
+<br/>
 <a href="https://github.com/trevorswan11/ghoti/issues/new?labels=bug&template=bug-report.md">Report Bug</a>
 &middot;
 <a href="https://github.com/trevorswan11/ghoti/issues/new?labels=enhancement&template=feature-request.md">Request Feature</a>
@@ -78,7 +78,7 @@ pub const main := fn(args: [][:0]u8): void {
 
 ## Getting Started
 ### For Nix Users
-This is by far the easiest way to get started with development. Just run `nix develop` to get started and automatically get the correct Zig version and some important development tools. Note that this provides optional preconfigured tools such as LLDB, Clangd, and ZLS to further enhance the developer experience.
+This is by far the easiest way to get started with development. Just run `nix develop` to get started and automatically get the correct Zig and Go versions as well as some other important development tools. Note that this provides optional preconfigured tools such as LLDB, Clangd, and ZLS to further enhance the developer experience.
 
 ### For Others
 All you need to get started with ghoti development is git and a valid 0.16.0 Zig installation, which can be found [here](https://ziglang.org/download/).
@@ -89,6 +89,9 @@ git clone https://github.com/trevorswan11/ghoti
 cd ghoti
 zig build --release
 ```
+
+## Language Website
+The language's website is written with [Go](https://go.dev/), [HTMX](https://htmx.org/), and [templ](https://github.com/a-h/templ). To build the website, you'll need [go1.26.4](https://go.dev/dl/) on top of the aforementioned Zig version. Once these dependencies are installed, you simply have to run `zig build site`, producing a binary in the `zig-out` directory.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ zig build --release
 ```
 
 ## Language Website
-The language's website is written with [Go](https://go.dev/), [HTMX](https://htmx.org/), and [templ](https://github.com/a-h/templ). To build the website, you'll need [go1.26.4](https://go.dev/dl/) on top of the aforementioned Zig version. Once these dependencies are installed, you simply have to run `zig build site`, producing a binary in the `zig-out` directory.
+The language's website is written with [Go](https://go.dev/), [HTMX](https://htmx.org/), and [templ](https://github.com/a-h/templ). To build the website, you'll need [go1.26.3](https://go.dev/dl/) on top of the aforementioned Zig version. Once these dependencies are installed, you simply have to run `zig build site`, producing a binary in the `zig-out` directory.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ zig build --release
 ```
 
 ## Language Website
-The language's website is written with [Go](https://go.dev/), [HTMX](https://htmx.org/), and [templ](https://github.com/a-h/templ). To build the website, you'll need [go1.26.3](https://go.dev/dl/) on top of the aforementioned Zig version. Once these dependencies are installed, you simply have to run `zig build site`, producing a binary in the `zig-out` directory.
+The language's website is written with [Go](https://go.dev/), [HTMX](https://htmx.org/), and [templ](https://github.com/a-h/templ). To build the website, you'll need [go1.26.3](https://go.dev/dl/) on top of the aforementioned Zig version. Once these dependencies are installed, you simply have to run `zig build site`, producing a binary in the `zig-out` directory. 
+
+### Development
+[air](https://github.com/air-verse/air) is used for live reloading of the site during development. It and the aforementioned `templ` dependency are build from source, though they both bring in some transitive dependencies that are managed by Go. It is not expected that you have either of these tools installed to work on this project, though you may find it useful to provide `templ` to your editor in such a way that you can take advantage of its bundled LSP.
 
 ## Roadmap
 

--- a/build.zig
+++ b/build.zig
@@ -1386,14 +1386,17 @@ const SiteBuilder = struct {
     work_update_src: *std.Build.Step.UpdateSourceFiles = undefined,
 
     fn init(b: *std.Build, optimize: std.builtin.OptimizeMode) !?*SiteBuilder {
+        const go_path = b.findProgram(&.{"go"}, &.{}) catch return null;
+        const templ_dep = b.lazyDependency("templ", .{}) orelse return null;
+
         const self = try b.allocator.create(SiteBuilder);
         self.* = .{
             .b = b,
             .optimize = optimize,
-            .go_exe_path = b.findProgram(&.{"go"}, &.{}) catch return null,
+            .go_exe_path = go_path,
             .go_fmt_path = b.findProgram(&.{"gofmt"}, &.{}) catch null,
             .templ = .{
-                .dep = b.dependency("templ", .{}),
+                .dep = templ_dep,
             },
         };
 

--- a/build.zig
+++ b/build.zig
@@ -74,11 +74,15 @@ pub fn build(b: *std.Build) !void {
     });
     for (cdb_steps.items) |cdb_step| cdb_gen.step.dependOn(cdb_step);
 
+    const site_builder = try SiteBuilder.init(b, optimize);
+    if (site_builder) |site| site.build();
+
     clang.build();
     try addTooling(b, .{
         .cdb_gen = cdb_gen,
         .clang = clang,
         .cppcheck = artifacts.cppcheck.?,
+        .site_builder = site_builder,
     });
 
     try addPackageStep(b, .{
@@ -136,6 +140,7 @@ const ProjectPaths = struct {
         });
     }
 
+    const site = "site/";
     const third_party = "third-party/";
 };
 
@@ -776,6 +781,7 @@ fn addTooling(b: *std.Build, config: struct {
     cdb_gen: *CDBGenerator,
     clang: *ClangBuilder,
     cppcheck: *std.Build.Step.Compile,
+    site_builder: ?*SiteBuilder,
 }) !void {
     const tooling_sources = try ProjectPaths.collectCXXToolingFiles(b);
 
@@ -786,12 +792,14 @@ fn addTooling(b: *std.Build, config: struct {
     try addFmtStep(b, .{
         .tooling_sources = tooling_sources,
         .clang = config.clang,
+        .site_builder = config.site_builder,
     });
 
     const check_step = addStaticAnalysisStep(b, .{
         .tooling_sources = tooling_sources,
         .cppcheck = config.cppcheck,
         .cdb_gen = config.cdb_gen,
+        .site_builder = config.site_builder,
     });
     check_step.dependOn(&config.cdb_gen.step);
 
@@ -803,6 +811,7 @@ fn addTooling(b: *std.Build, config: struct {
 fn addFmtStep(b: *std.Build, config: struct {
     tooling_sources: []const []const u8,
     clang: *ClangBuilder,
+    site_builder: ?*SiteBuilder,
 }) !void {
     const clang_format = config.clang.clang_tools.clang_format;
     const zig_paths = try collectFiles(b, "tools", .{
@@ -828,12 +837,38 @@ fn addFmtStep(b: *std.Build, config: struct {
     const fmt_check_step = b.step("fmt-check", "Check formatting of all project files");
     fmt_check_step.dependOn(&fmt_check.step);
     fmt_check_step.dependOn(&build_fmt_check.step);
+
+    if (config.site_builder) |site| if (site.go_fmt_path) |go_fmt| {
+        const go_paths = try collectFiles(b, ProjectPaths.site, .{
+            .allowed_extensions = &.{".go"},
+            .dropped_extensions = &.{"_templ.go"},
+        });
+
+        const go_formatter = b.addSystemCommand(&.{ go_fmt, "-w" });
+        go_formatter.addArgs(go_paths);
+        fmt_step.dependOn(&go_formatter.step);
+
+        const templ_formatter = site.addRunTempl();
+        templ_formatter.setCwd(b.path(ProjectPaths.site));
+        templ_formatter.addArgs(&.{ "fmt", "." });
+        fmt_step.dependOn(&templ_formatter.step);
+
+        const go_formatter_check = b.addSystemCommand(&.{ go_fmt, "-d" });
+        go_formatter_check.addArgs(go_paths);
+        fmt_check_step.dependOn(&go_formatter_check.step);
+
+        const templ_formatter_check = site.addRunTempl();
+        templ_formatter_check.setCwd(b.path(ProjectPaths.site));
+        templ_formatter_check.addArgs(&.{ "fmt", "-fail", "." });
+        fmt_check_step.dependOn(&templ_formatter_check.step);
+    };
 }
 
 fn addStaticAnalysisStep(b: *std.Build, config: struct {
     tooling_sources: []const []const u8,
     cppcheck: *std.Build.Step.Compile,
     cdb_gen: *CDBGenerator,
+    site_builder: ?*SiteBuilder,
 }) *std.Build.Step {
     const check_step = b.step("check", "Run static analysis on all project files");
     const cppcheck_run = b.addRunArtifact(config.cppcheck);
@@ -880,6 +915,13 @@ fn addStaticAnalysisStep(b: *std.Build, config: struct {
     cppcheck_cache_install.step.dependOn(&config.cppcheck.step);
     check_step.dependOn(&cppcheck_cache_install.step);
     check_step.dependOn(&cppcheck_run.step);
+
+    if (config.site_builder) |site| {
+        const go_vet = site.addRunGo();
+        go_vet.setCwd(b.path(ProjectPaths.site));
+        go_vet.addArgs(&.{ "vet", "./..." });
+        check_step.dependOn(&go_vet.step);
+    }
     return check_step;
 }
 
@@ -1324,11 +1366,135 @@ const CoverageParser = struct {
     }
 };
 
+const SiteBuilder = struct {
+    const Templ = struct {
+        dep: *std.Build.Dependency,
+        artifact_path: std.Build.LazyPath = undefined,
+        install_file: *std.Build.Step.InstallFile = undefined,
+    };
+
+    const go_work = "go.work";
+    const templ_exe = "templ";
+    const server_exe = "ghoti-server";
+
+    b: *std.Build,
+    optimize: std.builtin.OptimizeMode,
+
+    go_exe_path: []const u8,
+    go_fmt_path: ?[]const u8,
+    templ: Templ,
+    work_update_src: *std.Build.Step.UpdateSourceFiles = undefined,
+
+    fn init(b: *std.Build, optimize: std.builtin.OptimizeMode) !?*SiteBuilder {
+        const self = try b.allocator.create(SiteBuilder);
+        self.* = .{
+            .b = b,
+            .optimize = optimize,
+            .go_exe_path = b.findProgram(&.{"go"}, &.{}) catch return null,
+            .go_fmt_path = b.findProgram(&.{"gofmt"}, &.{}) catch null,
+            .templ = .{
+                .dep = b.dependency("templ", .{}),
+            },
+        };
+
+        const run = self.addRunGoBuild();
+        run.setCwd(self.templ.dep.path("cmd/templ"));
+        self.templ.artifact_path = run.addOutputFileArg(templ_exe);
+        self.templ.install_file = self.addInstallFile(self.templ.artifact_path, templ_exe);
+        self.work_update_src = try self.addTemplWork();
+
+        b.getInstallStep().dependOn(&self.work_update_src.step);
+
+        return self;
+    }
+
+    fn build(self: *SiteBuilder) void {
+        const b = self.b;
+        const generator = self.addRunTempl();
+        generator.setCwd(b.path(ProjectPaths.site));
+        generator.addArg("generate");
+        generator.has_side_effects = true;
+
+        const builder = self.addRunGoBuild();
+        builder.setCwd(b.path(ProjectPaths.site ++ "cmd/server"));
+        builder.step.dependOn(&generator.step);
+        builder.has_side_effects = true;
+
+        const server_path = builder.addOutputFileArg(server_exe);
+        const server_install = self.addInstallFile(server_path, server_exe);
+        const build_site = b.step("site", "Build and install the project's website");
+        build_site.dependOn(&server_install.step);
+
+        const run_site_run: *std.Build.Step.Run = .create(self.b, "run templ");
+        run_site_run.addFileArg(server_path);
+        const run_site = b.step("run-site", "Build, install, and run the project's website");
+        run_site.dependOn(&run_site_run.step);
+    }
+
+    fn addTemplWork(self: *const SiteBuilder) !*std.Build.Step.UpdateSourceFiles {
+        const b = self.b;
+        const templ_path = try self.templ.dep.path(".").getPath4(b, null);
+        const go_work_content = b.fmt(
+            \\go 1.26.3
+            \\
+            \\use (
+            \\  .
+            \\  {s}
+            \\)
+        , .{try templ_path.toString(b.allocator)});
+        const write_work = b.addWriteFile(go_work, go_work_content);
+        const gen_work = write_work.getDirectory().path(b, go_work);
+        const update = b.addUpdateSourceFiles();
+        update.addCopyFileToSource(gen_work, ProjectPaths.site ++ go_work);
+        return update;
+    }
+
+    fn addRunGo(self: *const SiteBuilder) *std.Build.Step.Run {
+        return self.b.addSystemCommand(&.{self.go_exe_path});
+    }
+
+    fn addRunGoBuild(self: *const SiteBuilder) *std.Build.Step.Run {
+        const run = self.addRunGo();
+        run.addArg("build");
+        run.addArgs(self.getGoOptimizeFlags());
+        run.addArg("-o");
+        return run;
+    }
+
+    fn addInstallFile(
+        self: *const SiteBuilder,
+        path: std.Build.LazyPath,
+        executable: []const u8,
+    ) *std.Build.Step.InstallFile {
+        const b = self.b;
+        return b.addInstallFileWithDir(
+            path,
+            .{ .custom = ProjectPaths.site },
+            tryAppendExe(b, executable),
+        );
+    }
+
+    fn addRunTempl(self: *const SiteBuilder) *std.Build.Step.Run {
+        const run: *std.Build.Step.Run = .create(self.b, "run templ");
+        run.addFileArg(self.templ.artifact_path);
+        return run;
+    }
+
+    fn getGoOptimizeFlags(self: *const SiteBuilder) []const []const u8 {
+        return switch (self.optimize) {
+            .Debug => return &.{ "-race", "-gcflags=all=-N -l" },
+            .ReleaseSmall => return &.{ "-ldflags=-s -w", "-trimpath" },
+            .ReleaseFast, .ReleaseSafe => return &.{"-ldflags=-s -w"},
+        };
+    }
+};
+
 const CollectFilesConfig = struct {
     allowed_extensions: []const []const u8 = &.{".cc"},
     dropped_files: ?[]const []const u8 = null,
     extra_files: ?[]const []const u8 = null,
     return_basenames_only: bool = false,
+    dropped_extensions: ?[]const []const u8 = null,
 };
 
 fn collectFiles(
@@ -1344,7 +1510,7 @@ fn collectFiles(
     defer walker.deinit();
 
     var paths: std.ArrayList([]const u8) = .empty;
-    while (try walker.next(io)) |entry| {
+    outer: while (try walker.next(io)) |entry| {
         if (entry.kind != .file) continue;
         for (config.allowed_extensions) |ext| {
             if (std.mem.endsWith(u8, entry.basename, ext)) break;
@@ -1352,6 +1518,10 @@ fn collectFiles(
 
         if (config.dropped_files) |drop| for (drop) |drop_file| {
             if (std.mem.eql(u8, drop_file, entry.basename)) continue;
+        };
+
+        if (config.dropped_extensions) |drop| for (drop) |drop_file| {
+            if (std.mem.endsWith(u8, entry.basename, drop_file)) continue :outer;
         };
 
         if (config.return_basenames_only) {
@@ -1366,4 +1536,11 @@ fn collectFiles(
         try paths.appendSlice(b.allocator, extra_files);
     }
     return paths.items;
+}
+
+fn tryAppendExe(b: *std.Build, raw_path: []const u8) []const u8 {
+    return b.fmt("{s}{s}", .{
+        raw_path,
+        if (b.graph.host.result.os.tag == .windows) ".exe" else "",
+    });
 }

--- a/build.zig
+++ b/build.zig
@@ -956,9 +956,9 @@ fn addStaticAnalysisStep(b: *std.Build, config: struct {
     check_step.dependOn(&cppcheck_run.step);
 
     if (config.site_builder) |site| {
-        const go_vet = b.addSystemCommand(&.{site.go_exe_path});
+        const go_vet = b.addSystemCommand(&.{ site.go_exe_path, "vet", "./..." });
         go_vet.setCwd(site.site_path);
-        go_vet.addArgs(&.{ "vet", "./..." });
+        go_vet.step.dependOn(&site.main_builder.step);
         check_step.dependOn(&go_vet.step);
     }
     return check_step;

--- a/build.zig
+++ b/build.zig
@@ -1367,13 +1367,12 @@ const CoverageParser = struct {
 };
 
 const SiteBuilder = struct {
-    const Templ = struct {
+    const GoDependency = struct {
         dep: *std.Build.Dependency,
         artifact_path: std.Build.LazyPath = undefined,
     };
 
     const go_work = "go.work";
-    const templ_exe = "templ";
     const server_exe = "ghoti-server";
 
     b: *std.Build,
@@ -1381,12 +1380,15 @@ const SiteBuilder = struct {
 
     go_exe_path: []const u8,
     go_fmt_path: ?[]const u8,
-    templ: Templ,
+    templ: GoDependency,
+    air: GoDependency,
     work_update_src: *std.Build.Step.UpdateSourceFiles = undefined,
 
     fn init(b: *std.Build, optimize: std.builtin.OptimizeMode) !?*SiteBuilder {
         const go_path = b.findProgram(&.{"go"}, &.{}) catch return null;
-        const templ_dep = b.lazyDependency("templ", .{}) orelse return null;
+        const templ_dep = b.lazyDependency("templ", .{});
+        const air_dep = b.lazyDependency("air", .{});
+        if (templ_dep == null or air_dep == null) return null;
 
         const self = try b.allocator.create(SiteBuilder);
         self.* = .{
@@ -1394,17 +1396,27 @@ const SiteBuilder = struct {
             .optimize = optimize,
             .go_exe_path = go_path,
             .go_fmt_path = b.findProgram(&.{"gofmt"}, &.{}) catch null,
-            .templ = .{
-                .dep = templ_dep,
-            },
+            .templ = .{ .dep = templ_dep.? },
+            .air = .{ .dep = air_dep.? },
         };
 
-        const run = self.addRunGoBuild();
-        run.setCwd(self.templ.dep.path("cmd/templ"));
-        self.templ.artifact_path = run.addOutputFileArg(templ_exe);
-        self.work_update_src = try self.addTemplWork();
+        try self.buildTempl();
+        self.buildAir();
 
         return self;
+    }
+
+    fn buildTempl(self: *SiteBuilder) !void {
+        const builder = self.addRunGoBuild(.ReleaseFast);
+        builder.setCwd(self.templ.dep.path("cmd/templ"));
+        self.templ.artifact_path = builder.addOutputFileArg("templ");
+        self.work_update_src = try self.addTemplWork();
+    }
+
+    fn buildAir(self: *SiteBuilder) void {
+        const builder = self.addRunGoBuild(.ReleaseFast);
+        builder.setCwd(self.templ.dep.path("."));
+        self.air.artifact_path = builder.addOutputFileArg("air");
     }
 
     fn build(self: *SiteBuilder) void {
@@ -1415,7 +1427,7 @@ const SiteBuilder = struct {
         generator.step.dependOn(&self.work_update_src.step);
         generator.has_side_effects = true;
 
-        const builder = self.addRunGoBuild();
+        const builder = self.addRunGoBuild(self.optimize);
         builder.setCwd(b.path(ProjectPaths.site ++ "cmd/server"));
         builder.step.dependOn(&generator.step);
         builder.has_side_effects = true;
@@ -1425,10 +1437,16 @@ const SiteBuilder = struct {
         const build_site = b.step("site", "Build and install the project's website");
         build_site.dependOn(&server_install.step);
 
-        const run_site_run: *std.Build.Step.Run = .create(self.b, "run templ");
+        const run_site_run: *std.Build.Step.Run = .create(self.b, "run site");
         run_site_run.addFileArg(server_path);
         const run_site = b.step("run-site", "Build, install, and run the project's website");
         run_site.dependOn(&run_site_run.step);
+
+        const watch_site_run: *std.Build.Step.Run = .create(self.b, "run air");
+        watch_site_run.addFileArg(self.air.artifact_path);
+        watch_site_run.setCwd(b.path(ProjectPaths.site));
+        const watch_site = b.step("watch-site", "Kick off live reloading of the project's website");
+        watch_site.dependOn(&watch_site_run.step);
     }
 
     fn addTemplWork(self: *const SiteBuilder) !*std.Build.Step.UpdateSourceFiles {
@@ -1453,10 +1471,10 @@ const SiteBuilder = struct {
         return self.b.addSystemCommand(&.{self.go_exe_path});
     }
 
-    fn addRunGoBuild(self: *const SiteBuilder) *std.Build.Step.Run {
+    fn addRunGoBuild(self: *const SiteBuilder, optimize: std.builtin.OptimizeMode) *std.Build.Step.Run {
         const run = self.addRunGo();
         run.addArg("build");
-        run.addArgs(self.getGoOptimizeFlags());
+        run.addArgs(getGoOptimizeFlags(optimize));
         run.addArg("-o");
         return run;
     }
@@ -1480,8 +1498,8 @@ const SiteBuilder = struct {
         return run;
     }
 
-    fn getGoOptimizeFlags(self: *const SiteBuilder) []const []const u8 {
-        return switch (self.optimize) {
+    fn getGoOptimizeFlags(optimize: std.builtin.OptimizeMode) []const []const u8 {
+        return switch (optimize) {
             .Debug => return &.{ "-race", "-gcflags=all=-N -l" },
             .ReleaseSmall => return &.{ "-ldflags=-s -w", "-trimpath" },
             .ReleaseFast, .ReleaseSafe => return &.{"-ldflags=-s -w"},

--- a/build.zig
+++ b/build.zig
@@ -64,6 +64,9 @@ pub fn build(b: *std.Build) !void {
         "Install tests without running them (default: false)",
     ) orelse false;
 
+    const site_builder = try SiteBuilder.init(b, optimize);
+    if (site_builder) |site| try site.build();
+
     var cdb_steps: std.ArrayList(*std.Build.Step) = .empty;
     const artifacts = try addArtifacts(b, .{
         .optimize = optimize,
@@ -71,11 +74,9 @@ pub fn build(b: *std.Build) !void {
         .cxx_flags = compiler_flags.items,
         .cdb_steps = &cdb_steps,
         .install_tests_only = install_tests_only,
+        .site_builder = site_builder,
     });
     for (cdb_steps.items) |cdb_step| cdb_gen.step.dependOn(cdb_step);
-
-    const site_builder = try SiteBuilder.init(b, optimize);
-    if (site_builder) |site| site.build();
 
     clang.build();
     try addTooling(b, .{
@@ -183,10 +184,16 @@ const ExecutableBehavior = union(enum) {
 };
 
 const TestArtifacts = struct {
+    const WebserverTests = struct {
+        run: *std.Build.Step.Run,
+        install: *std.Build.Step.InstallDir,
+    };
+
     harness_tests: *std.Build.Step.Compile = undefined,
     support_tests: *std.Build.Step.Compile = undefined,
     compiler_tests: *std.Build.Step.Compile = undefined,
     driver_tests: *std.Build.Step.Compile = undefined,
+    webserver_tests: ?WebserverTests = null,
 
     pub fn configure(
         self: *const TestArtifacts,
@@ -217,6 +224,13 @@ const TestArtifacts = struct {
                 install_dir,
                 install_only,
             );
+        }
+
+        if (self.webserver_tests) |webserver_tests| {
+            if (install_only) {
+                webserver_tests.run.addArg("-c");
+            }
+            test_step.dependOn(&webserver_tests.install.step);
         }
     }
 };
@@ -253,6 +267,7 @@ fn addArtifacts(b: *std.Build, config: struct {
     auto_install: bool = true,
     packaging: bool = false,
     install_tests_only: bool = true,
+    site_builder: ?*SiteBuilder = null,
 }) !struct {
     libsupport: *std.Build.Step.Compile,
     libcompiler: *std.Build.Step.Compile,
@@ -518,11 +533,33 @@ fn addArtifacts(b: *std.Build, config: struct {
             },
         });
 
+        var webserver_tests: ?TestArtifacts.WebserverTests = null;
+        if (config.site_builder) |site| {
+            const ws_run = b.addSystemCommand(&.{ site.go_exe_path, "test", "./...", "-o" });
+            ws_run.setCwd(site.site_path);
+            ws_run.has_side_effects = true;
+            const ws_tests = ws_run.addOutputDirectoryArg("webserver");
+            const ws_install = b.addInstallDirectory(.{
+                .source_dir = ws_tests,
+                .install_dir = .{ .custom = "tests" },
+                .install_subdir = "webserver",
+            });
+
+            const step = b.step("test-webserver", "Build/run the webserver's tests");
+            step.dependOn(&ws_install.step);
+
+            webserver_tests = .{
+                .run = ws_run,
+                .install = ws_install,
+            };
+        }
+
         tests = .{
             .harness_tests = harness,
             .support_tests = support_tests,
             .compiler_tests = compiler_tests,
             .driver_tests = driver_tests,
+            .webserver_tests = webserver_tests,
         };
         try tests.?.configure(b, config.cdb_steps, test_install_dir, config.install_tests_only);
     }
@@ -819,6 +856,7 @@ fn addFmtStep(b: *std.Build, config: struct {
         .extra_files = &.{
             "build.zig",
             "build.zig.zon",
+            ProjectPaths.site ++ "rebuild.zig",
         },
     });
     const build_fmt = b.addFmt(.{ .paths = zig_paths });
@@ -849,7 +887,7 @@ fn addFmtStep(b: *std.Build, config: struct {
         fmt_step.dependOn(&go_formatter.step);
 
         const templ_formatter = site.addRunTempl();
-        templ_formatter.setCwd(b.path(ProjectPaths.site));
+        templ_formatter.setCwd(site.site_path);
         templ_formatter.addArgs(&.{ "fmt", "." });
         fmt_step.dependOn(&templ_formatter.step);
 
@@ -858,7 +896,7 @@ fn addFmtStep(b: *std.Build, config: struct {
         fmt_check_step.dependOn(&go_formatter_check.step);
 
         const templ_formatter_check = site.addRunTempl();
-        templ_formatter_check.setCwd(b.path(ProjectPaths.site));
+        templ_formatter_check.setCwd(site.site_path);
         templ_formatter_check.addArgs(&.{ "fmt", "-fail", "." });
         fmt_check_step.dependOn(&templ_formatter_check.step);
     };
@@ -917,8 +955,8 @@ fn addStaticAnalysisStep(b: *std.Build, config: struct {
     check_step.dependOn(&cppcheck_run.step);
 
     if (config.site_builder) |site| {
-        const go_vet = site.addRunGo();
-        go_vet.setCwd(b.path(ProjectPaths.site));
+        const go_vet = b.addSystemCommand(&.{site.go_exe_path});
+        go_vet.setCwd(site.site_path);
         go_vet.addArgs(&.{ "vet", "./..." });
         check_step.dependOn(&go_vet.step);
     }
@@ -1013,7 +1051,7 @@ const LOCCounter = struct {
             }),
             try collectFiles(b, "ghoti", .{ .allowed_extensions = &counted_extensions }),
             try collectFiles(b, "tools", .{ .allowed_extensions = &counted_extensions }),
-            try collectFiles(b, "doc", .{ .allowed_extensions = &counted_extensions }),
+            try collectFiles(b, "site", .{ .allowed_extensions = &counted_extensions }),
         });
 
         const build_dir = b.build_root.handle;
@@ -1370,18 +1408,27 @@ const SiteBuilder = struct {
     const GoDependency = struct {
         dep: *std.Build.Dependency,
         artifact_path: std.Build.LazyPath = undefined,
+        builder: *std.Build.Step.Run = undefined,
+        install: *std.Build.Step.InstallFile = undefined,
     };
 
+    const output_path = "site/";
+    const output_dev_path = output_path ++ "dev/";
     const go_work = "go.work";
-    const server_exe = "ghoti-server";
+    const webserver_exe = "webserver";
+    const devserver_exe = "devserver";
+    const templ_exe = "templ";
+    const air_exe = "air";
 
     b: *std.Build,
     optimize: std.builtin.OptimizeMode,
+    site_path: std.Build.LazyPath,
 
     go_exe_path: []const u8,
     go_fmt_path: ?[]const u8,
     templ: GoDependency,
     air: GoDependency,
+    rebuild: *std.Build.Step.Compile = undefined,
     work_update_src: *std.Build.Step.UpdateSourceFiles = undefined,
 
     fn init(b: *std.Build, optimize: std.builtin.OptimizeMode) !?*SiteBuilder {
@@ -1394,62 +1441,110 @@ const SiteBuilder = struct {
         self.* = .{
             .b = b,
             .optimize = optimize,
+            .site_path = b.path(ProjectPaths.site),
             .go_exe_path = go_path,
             .go_fmt_path = b.findProgram(&.{"gofmt"}, &.{}) catch null,
             .templ = .{ .dep = templ_dep.? },
             .air = .{ .dep = air_dep.? },
         };
+        return self;
+    }
 
+    /// This is fragile but I don't care
+    fn build(self: *SiteBuilder) !void {
         try self.buildTempl();
         self.buildAir();
-
-        return self;
+        self.buildRebuild();
+        self.buildOneShots();
+        self.buildWatch();
     }
 
     fn buildTempl(self: *SiteBuilder) !void {
         const builder = self.addRunGoBuild(.ReleaseFast);
         builder.setCwd(self.templ.dep.path("cmd/templ"));
-        self.templ.artifact_path = builder.addOutputFileArg("templ");
-        self.work_update_src = try self.addTemplWork();
+        self.templ.artifact_path = builder.addOutputFileArg(templ_exe);
+        self.templ.install = self.addInstallFile(self.templ.artifact_path, templ_exe, output_dev_path);
+        self.work_update_src = try self.addGoWork();
+        self.templ.builder = builder;
     }
 
     fn buildAir(self: *SiteBuilder) void {
         const builder = self.addRunGoBuild(.ReleaseFast);
-        builder.setCwd(self.templ.dep.path("."));
-        self.air.artifact_path = builder.addOutputFileArg("air");
+        builder.setCwd(self.air.dep.path("."));
+        self.air.artifact_path = builder.addOutputFileArg(air_exe);
+        self.air.install = self.addInstallFile(self.air.artifact_path, air_exe, output_dev_path);
+        self.air.builder = builder;
     }
 
-    fn build(self: *SiteBuilder) void {
+    fn buildRebuild(self: *SiteBuilder) void {
+        const b = self.b;
+        self.rebuild = self.b.addExecutable(.{
+            .name = "rebuild",
+            .root_module = b.addModule("rebuild", .{
+                .root_source_file = b.path("site/rebuild.zig"),
+                .target = b.graph.host,
+            }),
+        });
+        self.rebuild.step.dependOn(&self.templ.install.step);
+    }
+
+    fn buildOneShots(self: *SiteBuilder) void {
         const b = self.b;
         const generator = self.addRunTempl();
-        generator.setCwd(b.path(ProjectPaths.site));
+        generator.setCwd(self.site_path);
         generator.addArg("generate");
         generator.step.dependOn(&self.work_update_src.step);
         generator.has_side_effects = true;
 
         const builder = self.addRunGoBuild(self.optimize);
-        builder.setCwd(b.path(ProjectPaths.site ++ "cmd/server"));
+        builder.setCwd(self.site_path.path(b, "cmd/server"));
         builder.step.dependOn(&generator.step);
         builder.has_side_effects = true;
 
-        const server_path = builder.addOutputFileArg(server_exe);
-        const server_install = self.addInstallFile(server_path, server_exe);
+        const server_path = builder.addOutputFileArg(webserver_exe);
+        const server_install = self.addInstallFile(server_path, webserver_exe, output_path);
         const build_site = b.step("site", "Build and install the project's website");
         build_site.dependOn(&server_install.step);
 
-        const run_site_run: *std.Build.Step.Run = .create(self.b, "run site");
+        const run_site_run: *std.Build.Step.Run = .create(b, "run site");
         run_site_run.addFileArg(server_path);
         const run_site = b.step("run-site", "Build, install, and run the project's website");
         run_site.dependOn(&run_site_run.step);
+    }
 
-        const watch_site_run: *std.Build.Step.Run = .create(self.b, "run air");
+    fn buildWatch(self: *SiteBuilder) void {
+        const b = self.b;
+        const watch_site_run: *std.Build.Step.Run = .create(b, "run air");
+        watch_site_run.step.dependOn(&self.air.install.step);
+        const abs_dev_path = b.pathJoin(&.{ b.install_prefix, output_dev_path });
+        watch_site_run.setEnvironmentVariable("GHOTI_TEMPL_ARTIFACT", b.pathJoin(&.{
+            abs_dev_path,
+            self.templ.install.dest_rel_path,
+        }));
+        watch_site_run.setEnvironmentVariable("GHOTI_GO_PATH", self.go_exe_path);
+        const output = tryAppendExe(b, b.pathJoin(&.{ abs_dev_path, devserver_exe }));
+        watch_site_run.setEnvironmentVariable("GHOTI_SITE_OUTPUT", output);
+
         watch_site_run.addFileArg(self.air.artifact_path);
-        watch_site_run.setCwd(b.path(ProjectPaths.site));
+        watch_site_run.addArg("--build.cmd");
+        watch_site_run.addArtifactArg(self.rebuild);
+        watch_site_run.addArgs(&.{
+            "--build.entrypoint",
+            output,
+            "--build.include_ext",
+            "go,templ",
+            "--build.exclude_regex",
+            ".*_templ.go,.*_test.go",
+            "-tmp_dir",
+            abs_dev_path,
+        });
+        watch_site_run.setCwd(self.site_path);
+
         const watch_site = b.step("watch-site", "Kick off live reloading of the project's website");
         watch_site.dependOn(&watch_site_run.step);
     }
 
-    fn addTemplWork(self: *const SiteBuilder) !*std.Build.Step.UpdateSourceFiles {
+    fn addGoWork(self: *const SiteBuilder) !*std.Build.Step.UpdateSourceFiles {
         const b = self.b;
         const templ_path = try self.templ.dep.path(".").getPath4(b, null);
         const go_work_content = b.fmt(
@@ -1467,12 +1562,8 @@ const SiteBuilder = struct {
         return update;
     }
 
-    fn addRunGo(self: *const SiteBuilder) *std.Build.Step.Run {
-        return self.b.addSystemCommand(&.{self.go_exe_path});
-    }
-
     fn addRunGoBuild(self: *const SiteBuilder, optimize: std.builtin.OptimizeMode) *std.Build.Step.Run {
-        const run = self.addRunGo();
+        const run = self.b.addSystemCommand(&.{self.go_exe_path});
         run.addArg("build");
         run.addArgs(getGoOptimizeFlags(optimize));
         run.addArg("-o");
@@ -1483,11 +1574,12 @@ const SiteBuilder = struct {
         self: *const SiteBuilder,
         path: std.Build.LazyPath,
         executable: []const u8,
+        prefix_path: []const u8,
     ) *std.Build.Step.InstallFile {
         const b = self.b;
         return b.addInstallFileWithDir(
             path,
-            .{ .custom = ProjectPaths.site },
+            .{ .custom = prefix_path },
             tryAppendExe(b, executable),
         );
     }

--- a/build.zig
+++ b/build.zig
@@ -1370,7 +1370,6 @@ const SiteBuilder = struct {
     const Templ = struct {
         dep: *std.Build.Dependency,
         artifact_path: std.Build.LazyPath = undefined,
-        install_file: *std.Build.Step.InstallFile = undefined,
     };
 
     const go_work = "go.work";
@@ -1403,10 +1402,7 @@ const SiteBuilder = struct {
         const run = self.addRunGoBuild();
         run.setCwd(self.templ.dep.path("cmd/templ"));
         self.templ.artifact_path = run.addOutputFileArg(templ_exe);
-        self.templ.install_file = self.addInstallFile(self.templ.artifact_path, templ_exe);
         self.work_update_src = try self.addTemplWork();
-
-        b.getInstallStep().dependOn(&self.work_update_src.step);
 
         return self;
     }
@@ -1416,6 +1412,7 @@ const SiteBuilder = struct {
         const generator = self.addRunTempl();
         generator.setCwd(b.path(ProjectPaths.site));
         generator.addArg("generate");
+        generator.step.dependOn(&self.work_update_src.step);
         generator.has_side_effects = true;
 
         const builder = self.addRunGoBuild();

--- a/build.zig
+++ b/build.zig
@@ -537,13 +537,14 @@ fn addArtifacts(b: *std.Build, config: struct {
         if (config.site_builder) |site| {
             const ws_run = b.addSystemCommand(&.{ site.go_exe_path, "test", "./...", "-o" });
             ws_run.setCwd(site.site_path);
-            ws_run.has_side_effects = true;
             const ws_tests = ws_run.addOutputDirectoryArg("webserver");
             const ws_install = b.addInstallDirectory(.{
                 .source_dir = ws_tests,
                 .install_dir = .{ .custom = "tests" },
                 .install_subdir = "webserver",
             });
+            ws_run.has_side_effects = true;
+            ws_run.step.dependOn(&site.main_builder.step);
 
             const step = b.step("test-webserver", "Build/run the webserver's tests");
             step.dependOn(&ws_install.step);
@@ -1428,6 +1429,7 @@ const SiteBuilder = struct {
     go_fmt_path: ?[]const u8,
     templ: GoDependency,
     air: GoDependency,
+    main_builder: *std.Build.Step.Run = undefined,
     rebuild: *std.Build.Step.Compile = undefined,
     work_update_src: *std.Build.Step.UpdateSourceFiles = undefined,
 
@@ -1500,6 +1502,7 @@ const SiteBuilder = struct {
         builder.setCwd(self.site_path.path(b, "cmd/server"));
         builder.step.dependOn(&generator.step);
         builder.has_side_effects = true;
+        self.main_builder = builder;
 
         const server_path = builder.addOutputFileArg(webserver_exe);
         const server_install = self.addInstallFile(server_path, webserver_exe, output_path);

--- a/build.zig
+++ b/build.zig
@@ -940,10 +940,9 @@ const LOCCounter = struct {
         }
     };
 
-    const counted_extensions = [_][]const u8{ ".cc", ".hh", ".inc", ".zig", ".gh" };
-    const dropped_file_config: CollectFilesConfig = .{
-        .allowed_extensions = &.{ ".zig", ".h", ".in" },
-        .return_basenames_only = true,
+    const counted_extensions = [_][]const u8{
+        ".cc", ".hh",    ".inc",  ".zig", ".gh",
+        ".go", ".templ", ".html", ".css",
     };
 
     step: std.Build.Step,
@@ -972,6 +971,7 @@ const LOCCounter = struct {
             }),
             try collectFiles(b, "ghoti", .{ .allowed_extensions = &counted_extensions }),
             try collectFiles(b, "tools", .{ .allowed_extensions = &counted_extensions }),
+            try collectFiles(b, "doc", .{ .allowed_extensions = &counted_extensions }),
         });
 
         const build_dir = b.build_root.handle;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -94,6 +94,7 @@
         .templ = .{
             .url = "https://github.com/a-h/templ/archive/refs/tags/v0.3.1020.tar.gz",
             .hash = "N-V-__8AAO9_ZADApu4jwKaHH7PBgOW7scl3NXxVkz9e0Q3V",
+            .lazy = true,
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -96,6 +96,11 @@
             .hash = "N-V-__8AAO9_ZADApu4jwKaHH7PBgOW7scl3NXxVkz9e0Q3V",
             .lazy = true,
         },
+        .air = .{
+            .url = "https://github.com/air-verse/air/archive/refs/tags/v1.65.3.tar.gz",
+            .hash = "N-V-__8AAFo6FADbZ1JQ7LPdl743CwRi8TYtXnj_23IuzHTs",
+            .lazy = true,
+        },
     },
     .paths = .{
         "ghoti",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -91,10 +91,15 @@
             .hash = "N-V-__8AAESGsACJHNukVw9fMHuLowaKWinuxfGbHF4W554F",
             .lazy = true,
         },
+        .templ = .{
+            .url = "https://github.com/a-h/templ/archive/refs/tags/v0.3.1020.tar.gz",
+            .hash = "N-V-__8AAO9_ZADApu4jwKaHH7PBgOW7scl3NXxVkz9e0Q3V",
+        },
     },
     .paths = .{
-        "lib",
         "ghoti",
+        "lib",
+        "site",
         "tools",
         "third-party",
         "build.zig",

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1776398705,
-        "narHash": "sha256-/RYhj2fmbFWjfNORGjI18rJzLICNahxPSy0epCdyVRk=",
+        "lastModified": 1781486619,
+        "narHash": "sha256-Q7bjYzhwZdbqmMOY+d/3lNt6ilzh8XzBlsYGa9BbiX0=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "e2956eb5a19f92fef466f1af78f1fb8c207767af",
+        "rev": "7a81937e0992295dec2bfa070da52a79188007a9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,174 +1,271 @@
 {
-  "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
+    "nodes": {
+        "flake-compat": {
+            "flake": false,
+            "locked": {
+                "lastModified": 1696426674,
+                "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+                "owner": "edolstra",
+                "repo": "flake-compat",
+                "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+                "type": "github"
+            },
+            "original": {
+                "owner": "edolstra",
+                "repo": "flake-compat",
+                "type": "github"
+            }
+        },
+        "flake-utils": {
+            "inputs": {
+                "systems": "systems"
+            },
+            "locked": {
+                "lastModified": 1731533236,
+                "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+                "owner": "numtide",
+                "repo": "flake-utils",
+                "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+                "type": "github"
+            },
+            "original": {
+                "owner": "numtide",
+                "repo": "flake-utils",
+                "type": "github"
+            }
+        },
+        "gitignore": {
+            "inputs": {
+                "nixpkgs": [
+                    "templ-flake",
+                    "nixpkgs"
+                ]
+            },
+            "locked": {
+                "lastModified": 1762808025,
+                "narHash": "sha256-XmjITeZNMTQXGhhww6ed/Wacy2KzD6svioyCX7pkUu4=",
+                "owner": "hercules-ci",
+                "repo": "gitignore.nix",
+                "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
+                "type": "github"
+            },
+            "original": {
+                "owner": "hercules-ci",
+                "repo": "gitignore.nix",
+                "type": "github"
+            }
+        },
+        "nixpkgs": {
+            "locked": {
+                "lastModified": 1781074563,
+                "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+                "owner": "nixos",
+                "repo": "nixpkgs",
+                "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+                "type": "github"
+            },
+            "original": {
+                "owner": "nixos",
+                "ref": "nixos-unstable",
+                "repo": "nixpkgs",
+                "type": "github"
+            }
+        },
+        "nixpkgs-unstable": {
+            "locked": {
+                "lastModified": 1777954456,
+                "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+                "owner": "NixOS",
+                "repo": "nixpkgs",
+                "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+                "type": "github"
+            },
+            "original": {
+                "owner": "NixOS",
+                "ref": "nixos-unstable",
+                "repo": "nixpkgs",
+                "type": "github"
+            }
+        },
+        "nixpkgs_2": {
+            "locked": {
+                "lastModified": 1778003029,
+                "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+                "owner": "NixOS",
+                "repo": "nixpkgs",
+                "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+                "type": "github"
+            },
+            "original": {
+                "owner": "NixOS",
+                "ref": "nixos-25.11",
+                "repo": "nixpkgs",
+                "type": "github"
+            }
+        },
+        "nixpkgs_3": {
+            "locked": {
+                "lastModified": 1771043024,
+                "narHash": "sha256-O1XDr7EWbRp+kHrNNgLWgIrB0/US5wvw9K6RERWAj6I=",
+                "owner": "NixOS",
+                "repo": "nixpkgs",
+                "rev": "3aadb7ca9eac2891d52a9dec199d9580a6e2bf44",
+                "type": "github"
+            },
+            "original": {
+                "owner": "NixOS",
+                "ref": "nixos-25.11",
+                "repo": "nixpkgs",
+                "type": "github"
+            }
+        },
+        "root": {
+            "inputs": {
+                "flake-utils": "flake-utils",
+                "nixpkgs": "nixpkgs",
+                "templ-flake": "templ-flake",
+                "zig-flake": "zig-flake",
+                "zls-flake": "zls-flake"
+            }
+        },
+        "systems": {
+            "locked": {
+                "lastModified": 1681028828,
+                "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+                "owner": "nix-systems",
+                "repo": "default",
+                "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+                "type": "github"
+            },
+            "original": {
+                "owner": "nix-systems",
+                "repo": "default",
+                "type": "github"
+            }
+        },
+        "systems_2": {
+            "flake": false,
+            "locked": {
+                "lastModified": 1681028828,
+                "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+                "owner": "nix-systems",
+                "repo": "default",
+                "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+                "type": "github"
+            },
+            "original": {
+                "owner": "nix-systems",
+                "repo": "default",
+                "type": "github"
+            }
+        },
+        "templ-flake": {
+            "inputs": {
+                "gitignore": "gitignore",
+                "nixpkgs": "nixpkgs_2",
+                "nixpkgs-unstable": "nixpkgs-unstable",
+                "version": "version"
+            },
+            "locked": {
+                "lastModified": 1778534261,
+                "narHash": "sha256-jBk31rAttFMgBwXFC2vQY0+MNVu7Lj2po4+drtufsVY=",
+                "owner": "a-h",
+                "repo": "templ",
+                "rev": "f8e3a1b4efb329e94e4831e3ad494bbc2086b756",
+                "type": "github"
+            },
+            "original": {
+                "owner": "a-h",
+                "repo": "templ",
+                "type": "github"
+            }
+        },
+        "version": {
+            "inputs": {
+                "nixpkgs": [
+                    "templ-flake",
+                    "nixpkgs"
+                ]
+            },
+            "locked": {
+                "lastModified": 1749991223,
+                "narHash": "sha256-K6OM2m+Bdkbq7MvTIwI1t0aPIwmkLUDeUfev5VHpiwg=",
+                "owner": "a-h",
+                "repo": "version",
+                "rev": "da721166410c6e7e2bea37cf3dee3948b5d0c83f",
+                "type": "github"
+            },
+            "original": {
+                "owner": "a-h",
+                "ref": "0.0.10",
+                "repo": "version",
+                "type": "github"
+            }
+        },
+        "zig-flake": {
+            "inputs": {
+                "flake-compat": "flake-compat",
+                "nixpkgs": "nixpkgs_3",
+                "systems": "systems_2"
+            },
+            "locked": {
+                "lastModified": 1781486619,
+                "narHash": "sha256-Q7bjYzhwZdbqmMOY+d/3lNt6ilzh8XzBlsYGa9BbiX0=",
+                "owner": "mitchellh",
+                "repo": "zig-overlay",
+                "rev": "7a81937e0992295dec2bfa070da52a79188007a9",
+                "type": "github"
+            },
+            "original": {
+                "owner": "mitchellh",
+                "repo": "zig-overlay",
+                "type": "github"
+            }
+        },
+        "zig-flake_2": {
+            "inputs": {
+                "nixpkgs": [
+                    "zls-flake",
+                    "nixpkgs"
+                ]
+            },
+            "locked": {
+                "lastModified": 1776183664,
+                "narHash": "sha256-lmTMKC0Rc0L1GChNEAkn+hV/iaFMU4B2C9NkQqydumo=",
+                "owner": "silversquirl",
+                "repo": "zig-flake",
+                "rev": "2c9eec04c4a27ca54addd9e6c28a5a64906cba0a",
+                "type": "github"
+            },
+            "original": {
+                "owner": "silversquirl",
+                "repo": "zig-flake",
+                "type": "github"
+            }
+        },
+        "zls-flake": {
+            "inputs": {
+                "nixpkgs": [
+                    "nixpkgs"
+                ],
+                "zig-flake": "zig-flake_2"
+            },
+            "locked": {
+                "lastModified": 1776368637,
+                "narHash": "sha256-k0xWObsw9K12BKfK+UB5TieWDFEFfBQhN1X1NO35fWk=",
+                "owner": "zigtools",
+                "repo": "zls",
+                "rev": "494486203c3a48927f2383aa3d5ce5fca112186d",
+                "type": "github"
+            },
+            "original": {
+                "owner": "zigtools",
+                "ref": "0.16.0",
+                "repo": "zls",
+                "type": "github"
+            }
+        }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1771043024,
-        "narHash": "sha256-O1XDr7EWbRp+kHrNNgLWgIrB0/US5wvw9K6RERWAj6I=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3aadb7ca9eac2891d52a9dec199d9580a6e2bf44",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "root": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "zig-flake": "zig-flake",
-        "zls-flake": "zls-flake"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "zig-flake": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs_2",
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1781486619,
-        "narHash": "sha256-Q7bjYzhwZdbqmMOY+d/3lNt6ilzh8XzBlsYGa9BbiX0=",
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "rev": "7a81937e0992295dec2bfa070da52a79188007a9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "type": "github"
-      }
-    },
-    "zig-flake_2": {
-      "inputs": {
-        "nixpkgs": [
-          "zls-flake",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776183664,
-        "narHash": "sha256-lmTMKC0Rc0L1GChNEAkn+hV/iaFMU4B2C9NkQqydumo=",
-        "owner": "silversquirl",
-        "repo": "zig-flake",
-        "rev": "2c9eec04c4a27ca54addd9e6c28a5a64906cba0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "silversquirl",
-        "repo": "zig-flake",
-        "type": "github"
-      }
-    },
-    "zls-flake": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "zig-flake": "zig-flake_2"
-      },
-      "locked": {
-        "lastModified": 1776368637,
-        "narHash": "sha256-k0xWObsw9K12BKfK+UB5TieWDFEFfBQhN1X1NO35fWk=",
-        "owner": "zigtools",
-        "repo": "zls",
-        "rev": "494486203c3a48927f2383aa3d5ce5fca112186d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "zigtools",
-        "ref": "0.16.0",
-        "repo": "zls",
-        "type": "github"
-      }
-    }
-  },
-  "root": "root",
-  "version": 7
+    "root": "root",
+    "version": 7
 }

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
       flake-utils,
       zig-flake,
       zls-flake,
+      templ-flake,
       ...
     }:
     flake-utils.lib.eachDefaultSystem (
@@ -25,7 +26,7 @@
       let
         pkgs = import nixpkgs {
           inherit system;
-          templ = templ-tool.packages.${system}.templ;
+          templ = templ-flake.packages.${system}.templ;
           overlays = [
             (final: prev: {
               zig = zig-flake.packages.${system}."0.16.0";

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
             go
             gopls
             templ
+            prettier
           ]
           ++ (with llvmPackages_21; [
             clang-tools

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,8 @@
           buildInputs = [
             zig
             zls
+            go
+            gopls
           ]
           ++ (with llvmPackages_21; [
             clang-tools

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
       url = "github:zigtools/zls?ref=0.16.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    templ-flake.url = "github:a-h/templ";
   };
 
   outputs =
@@ -24,6 +25,7 @@
       let
         pkgs = import nixpkgs {
           inherit system;
+          templ = templ-tool.packages.${system}.templ;
           overlays = [
             (final: prev: {
               zig = zig-flake.packages.${system}."0.16.0";
@@ -40,6 +42,7 @@
             zls
             go
             gopls
+            templ
           ]
           ++ (with llvmPackages_21; [
             clang-tools

--- a/lib/compiler/include/ast/handle.hh
+++ b/lib/compiler/include/ast/handle.hh
@@ -13,6 +13,16 @@ namespace ghoti {
 
 namespace ast {
 
+namespace detail {
+
+// Checks if the provided kind is compatible with any allowed kind
+template <NodeKind... AllowedKinds>
+[[nodiscard]] constexpr auto any_kind_compatible(NodeKind kind) noexcept -> bool {
+    return ((kind == AllowedKinds) || ...);
+}
+
+} // namespace detail
+
 // A pseudo-type-safe wrapper around nodes, defaulting to an invalid state
 template <NodeKind... AllowedKinds> class Handle {
   public:
@@ -22,20 +32,13 @@ template <NodeKind... AllowedKinds> class Handle {
     }
 
     template <NodeKind... OtherKinds>
+        requires(detail::any_kind_compatible<AllowedKinds...>(OtherKinds) || ...)
     constexpr Handle(Handle<OtherKinds...> other) noexcept : id_{*other} {
-        // Shallow verify at compile time to enforce possible construction
-        static_assert((any_compatible(OtherKinds) || ...),
-                      "No requested kinds are compatible with provided ones");
-
-        // Runtime checks can be more specific to the actual state
         ASSERT(other.is_valid(), "Attempt to create Handle from invalid Handle");
-        ASSERT(((other.operator->()->get_kind() == AllowedKinds) || ...),
-               "Provided kind does not match");
     }
 
-    // Checks if the provided kind is compatible with any allowed kind
     [[nodiscard]] constexpr static auto any_compatible(NodeKind kind) noexcept -> bool {
-        return ((kind == AllowedKinds) || ...);
+        return detail::any_kind_compatible<AllowedKinds...>(kind);
     }
 
     [[nodiscard]] constexpr auto operator*() const noexcept -> NodeID { return id_; }
@@ -178,8 +181,6 @@ template <ast::NodeKind... Kinds> struct Nullable<ast::Handle<Kinds...>> {
         return handle.is_valid();
     }
 };
-
-static_assert(sizeof(opt::Option<ast::Handle<ast::NodeKind::ARRAY_EXPRESSION>>) == 8);
 
 } // namespace traits
 

--- a/lib/compiler/include/ast/id.hh
+++ b/lib/compiler/include/ast/id.hh
@@ -171,6 +171,10 @@ class TypeModifier {
     friend struct fmt::formatter<ghoti::ast::TypeModifier>;
 };
 
+static_assert(magic_enum::enum_count<ExplicitTypeKind>() <= 0xF, "ExplicitTypeKind enum too large");
+static_assert(magic_enum::enum_count<TypeModifier::Modifier>() <= 0xF,
+              "TypeModifier enum too large");
+
 // A compact id for all AST explicit types
 class ExplicitTypeID {
   public:
@@ -179,11 +183,6 @@ class ExplicitTypeID {
                              syntax::TokenType token_type,
                              u64               index) noexcept
         : raw_{} {
-        static_assert(magic_enum::enum_count<ExplicitTypeKind>() <= 0xF,
-                      "ExplicitTypeKind enum too large");
-        static_assert(magic_enum::enum_count<TypeModifier::Modifier>() <= 0xF,
-                      "TypeModifier enum too large");
-
         ASSERT(index <= INDEX_MASK, "Requested type index is too large");
         raw_ |= static_cast<u64>(kind) << KIND_OFFSET;
         raw_ |= static_cast<u64>(mod) << MODIFIER_OFFSET;

--- a/lib/support/include/arena.hh
+++ b/lib/support/include/arena.hh
@@ -34,16 +34,16 @@ class Arena {
 
     // Asserts that the requested type is at most 64KB
     template <traits::TriviallyDestructible T, typename... Args>
+        requires(sizeof(T) <= BLOCK_SIZE)
     [[nodiscard]] auto make(Args&&... args) -> gsl::not_null<T*> {
-        static_assert(sizeof(T) <= BLOCK_SIZE, "Block size cannot fit requested type");
         void* mem = alloc(sizeof(T), alignof(T));
         return new (mem) T{std::forward<Args>(args)...};
     }
 
     // Asserts that the requested type-count product can fit in 64KB
     template <traits::TriviallyDestructible T>
+        requires(sizeof(T) <= BLOCK_SIZE)
     [[nodiscard]] auto make_span(usize count) -> gsl::span<T> {
-        static_assert(sizeof(T) <= BLOCK_SIZE, "Block size cannot fit requested type");
         const auto size{sizeof(T) * count};
         ASSERT(size <= BLOCK_SIZE, "Block size cannot fit requested type count");
         void* mem = alloc(size, alignof(T));

--- a/lib/support/include/counter.hh
+++ b/lib/support/include/counter.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <concepts>
+
 #include "type_traits.hh"
 #include "types.hh"
 
@@ -35,16 +37,14 @@ template <traits::Integral Underlying> class Counter {
     constexpr auto               operator<=>(const Counter&) const noexcept        = default;
     [[nodiscard]] constexpr auto operator==(const Counter&) const noexcept -> bool = default;
 
-    template <typename T>
-        requires std::is_convertible_v<T, Underlying>
-    [[nodiscard]] constexpr auto operator==(const T& other) const noexcept -> bool {
-        return count_ == static_cast<Underlying>(other);
-    }
-
-    template <typename T>
-        requires std::is_convertible_v<T, Underlying>
+    template <std::convertible_to<Underlying> T>
     constexpr auto operator<=>(const T& other) const noexcept {
         return count_ <=> static_cast<Underlying>(other);
+    }
+
+    template <std::convertible_to<Underlying> T>
+    [[nodiscard]] constexpr auto operator==(const T& other) const noexcept -> bool {
+        return count_ == static_cast<Underlying>(other);
     }
 
     // Creates an RAII incrementor/decrementor object

--- a/lib/support/include/fixed/hash_map.hh
+++ b/lib/support/include/fixed/hash_map.hh
@@ -411,14 +411,12 @@ using HashMap = detail::HashMap<Key, Value, ceil_power_of_two(Capacity), Hash, C
 
 // Construct a hash map from a list of pairs
 template <traits::InsertablePair... Pairs>
+    requires(sizeof...(Pairs) > 0)
 [[nodiscard]] constexpr auto make_hash_map(Pairs&&... kv_pairs) noexcept {
-    constexpr usize slots{sizeof...(Pairs)};
-    static_assert(slots > 0, "HashMap must have a non-zero size");
-
     using std::get;
     HashMap<traits::common_tuple_type_t<0, Pairs...>,
             traits::common_tuple_type_t<1, Pairs...>,
-            slots>
+            sizeof...(Pairs)>
         map;
     (...,
      map.emplace(get<0>(std::forward<decltype(kv_pairs)>(kv_pairs)),

--- a/lib/support/include/fixed/vector.hh
+++ b/lib/support/include/fixed/vector.hh
@@ -33,8 +33,9 @@ template <typename Item, usize Capacity> class Vector {
     = default;
 
     // Constructs the vector in place by emplacing each item into the buffer
-    template <typename... Is> constexpr explicit Vector(Is&&... items) {
-        static_assert(sizeof...(Is) <= Capacity, "Cannot initialize with more items than capacity");
+    template <typename... Is>
+        requires(sizeof...(Is) <= Capacity)
+    constexpr explicit Vector(Is&&... items) {
         (..., emplace_back(std::forward<Is>(items)));
     }
 
@@ -131,8 +132,9 @@ template <typename Item, usize Capacity> class Vector {
 
   private:
     // https://en.cppreference.com/cpp/algorithm/swap
-    constexpr auto swap(Vector& other) noexcept -> void {
-        static_assert(!traits::TriviallyCopyable<Item>, "Trivial copies should be defaulted");
+    constexpr auto swap(Vector& other) noexcept -> void
+        requires(!traits::TriviallyCopyable<Item>)
+    {
         auto& smaller{(size_ < other.size_) ? *this : other};
         auto& larger{(size_ < other.size_) ? other : *this};
 

--- a/lib/support/include/option.hh
+++ b/lib/support/include/option.hh
@@ -104,9 +104,8 @@ template <typename T> class Ref {
     }
 
     template <typename Or>
+        requires requires(T& t) { static_cast<Or&>(t); }
     [[nodiscard]] constexpr auto value_or(this auto&& self, Or& or_value) -> T& {
-        static_assert(
-            requires(T& t) { static_cast<Or&>(t); }, "value_or: Or& must be convertible to T&");
         return self.has_value() ? *self.get() : static_cast<T&>(or_value);
     }
 
@@ -189,12 +188,9 @@ template <traits::Compactable T> class CompactOpt {
         return self.has_value() ? Ret{std::forward<F>(f)(self.value())} : Ret{};
     }
 
-    template <typename Or>
+    template <traits::CopyConstructible Or>
+        requires requires(const T& t) { static_cast<Or>(t); }
     [[nodiscard]] constexpr auto value_or(this auto&& self, Or&& or_value) -> decltype(auto) {
-        // This is straight from clang's stdc++ C++23 optional implementation
-        static_assert(traits::CopyConstructible<Or>, "value_or: Or must be copy constructible");
-        static_assert(
-            requires(const T& t) { static_cast<Or>(t); }, "value_or: Or must be convertible to T");
         return self.has_value() ? *self.get() : static_cast<T>(std::forward<Or>(or_value));
     }
 
@@ -275,10 +271,9 @@ class Tribool {
 
     [[nodiscard]] constexpr auto operator*() const noexcept -> bool { return get(); }
 
-    template <typename Or> [[nodiscard]] constexpr auto value_or(Or&& or_value) -> bool {
-        // This is straight from clang's stdc++ C++23 optional implementation
-        static_assert(traits::CopyConstructible<Or>, "value_or: Or must be copy constructible");
-        static_assert(std::is_convertible_v<Or, bool>, "value_or: Or must be convertible to T");
+    template <std::convertible_to<bool> Or>
+        requires traits::CopyConstructible<Or>
+    [[nodiscard]] constexpr auto value_or(Or&& or_value) -> bool {
         return has_value() ? get() : static_cast<bool>(std::forward<Or>(or_value));
     }
 

--- a/lib/support/include/result.hh
+++ b/lib/support/include/result.hh
@@ -35,10 +35,9 @@ template <typename E> class EmptyResult {
     [[nodiscard]] constexpr auto error(this auto&& self) -> auto& { return *self.error_; }
     [[nodiscard]] constexpr explicit operator bool() const noexcept { return has_value(); }
 
-    template <typename Or = E> constexpr auto error_or(Or&& or_value) const& {
-        // This is straight from clang's stdc++ C++23 expected implementation
-        static_assert(traits::CopyConstructible<Or>, "error_type has to be copy constructible");
-        static_assert(std::is_convertible_v<Or, E>, "argument has to be convertible to error_type");
+    template <std::convertible_to<E> Or = E>
+        requires traits::CopyConstructible<Or>
+    constexpr auto error_or(Or&& or_value) const& {
         if (has_value()) { return std::forward<Or>(or_value); }
         return error();
     }

--- a/site/cmd/server/main.go
+++ b/site/cmd/server/main.go
@@ -1,4 +1,4 @@
-package webserver
+package main
 
 import (
 	"fmt"

--- a/site/cmd/server/main.go
+++ b/site/cmd/server/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"site/views"
+
+	"github.com/a-h/templ"
+)
+
+func aaaaa() string {
+	return "done"
+}
+
+func main() {
+	http.Handle("/", templ.Handler(views.Hello("Trevor")))
+
+	port := ":3000"
+	fmt.Printf("Listening on %s\n", port)
+	http.ListenAndServe(port, nil)
+}

--- a/site/cmd/server/main.go
+++ b/site/cmd/server/main.go
@@ -1,17 +1,13 @@
-package main
+package webserver
 
 import (
 	"fmt"
 	"net/http"
 
-	"site/views"
+	"webserver/views"
 
 	"github.com/a-h/templ"
 )
-
-func aaaaa() string {
-	return "done"
-}
 
 func main() {
 	http.Handle("/", templ.Handler(views.Hello("Trevor")))

--- a/site/cmd/server/main_test.go
+++ b/site/cmd/server/main_test.go
@@ -1,4 +1,4 @@
-package webserver
+package main
 
 import "testing"
 

--- a/site/cmd/server/main_test.go
+++ b/site/cmd/server/main_test.go
@@ -1,0 +1,6 @@
+package webserver
+
+import "testing"
+
+func Placeholder(t *testing.T) {
+}

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,0 +1,5 @@
+module site
+
+go 1.26.3
+
+require github.com/a-h/templ v0.3.1020

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,4 +1,4 @@
-module site
+module webserver
 
 go 1.26.3
 

--- a/site/rebuild.zig
+++ b/site/rebuild.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub fn main(init: std.process.Init) !void {
+    const templ = init.environ_map.get("GHOTI_TEMPL_ARTIFACT") orelse return error.TemplNotFound;
+    var templ_proc = try std.process.spawn(init.io, .{
+        .argv = &.{ templ, "generate" },
+        .create_no_window = true,
+    });
+
+    switch (try templ_proc.wait(init.io)) {
+        .exited => |code| if (code != 0) std.process.exit(code),
+        else => std.process.exit(1),
+    }
+
+    const go = init.environ_map.get("GHOTI_GO_PATH") orelse return error.GoNotFound;
+    const output = init.environ_map.get("GHOTI_SITE_OUTPUT") orelse return error.OutputNotFound;
+    var go_proc = try std.process.spawn(init.io, .{
+        .argv = &.{ go, "build", "-o", output, "./cmd/server/main.go" },
+        .create_no_window = true,
+    });
+
+    switch (try go_proc.wait(init.io)) {
+        .exited => |code| if (code != 0) std.process.exit(code),
+        else => std.process.exit(1),
+    }
+}

--- a/site/views/hello.templ
+++ b/site/views/hello.templ
@@ -1,0 +1,5 @@
+package views
+
+templ Hello(name string) {
+	<div>Hello, { name }</div>
+}

--- a/site/views/hello_test.go
+++ b/site/views/hello_test.go
@@ -1,0 +1,6 @@
+package views
+
+import "testing"
+
+func Placeholder(t *testing.T) {
+}


### PR DESCRIPTION
## Description

Progress towards #80.

This change is coming because the language website is going to be fully implemented in Go, with HTMX and templ as supporting lirbaries/tools/frameworks. This will be a good learning experience and keeps me from having to use a ton of JS/TS and react which I'd rather restrict to work activities for now...

## Additional Context:

Adds Go to the Zig build system, detailing its usage in the README. Tooling is fully implemented for Go, from templ to air built in house and testing, formatting, and static analysis linked to the existing system. The associated dependencies are lazy as Go is not required for general language development.
